### PR TITLE
Add evidence-aware dry-run review for DeepRefine actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It refines your graphify knowledge graph for better future retrieval and Q&A qua
 
 ## News
 - **[2026/6/15] v0.1.8** - Aligned interaction memory with LLM-Wiki (graphify) and fixed the single query refinement issue.
+- **Unreleased** - Added dry-run-first refinement, evidence-aware action review, ambiguous-node warnings, and LOW-confidence apply guard.
 - **[2026/6/2] v0.1.7** — Cursor skill + `deeprefine refine` with configurable API. And strict DeepRefine agent loop.
 
 ## Agent CLI (Recommended)
@@ -51,6 +52,8 @@ This is the default mode and the main workflow for this project.
 - Follows the same control flow as `Reafiner.refine()`
 - Integrates with graphify query memory automatically
 - Handles pending queries in batch, one by one
+- Generates evidence-aware proposed actions before any graph write
+- Applies graph changes only after explicit user approval
 
 ### One-time setup
 
@@ -83,15 +86,17 @@ When you run `/deeprefine`, it should follow this order:
    - import queries from `graphify-out/memory/query_*.md`
    - write to `graphify-out/.deeprefine/history.jsonl`
 2. load pending queries from `history.jsonl` (`refined != true`)
-3. refine all pending queries sequentially
-4. mark each finished query as refined via `deeprefine loop finish`
+3. refine pending queries sequentially
+4. for refinement-path queries, generate `<refinement>` actions and run `deeprefine review`
+5. stop in dry-run mode and show the review report; do **not** modify `graph.json` yet
+6. only after user approval, run `deeprefine apply` and then `deeprefine loop finish`
 
 
 ### Agent artifacts
 
 ```text
 graphify-out/
-├── graph.json                              # graphify main graph (refined in-place)
+├── graph.json                              # graphify main graph; unchanged until apply approval
 ├── memory/
 │   └── query_*.md                          # graphify query logs (sync source)
 └── .deeprefine/
@@ -99,7 +104,10 @@ graphify-out/
     ├── graph.json.bak                      # backup before first apply in this run
     ├── loop_trace_<query_id>.json          # per-query loop audit trace
     ├── refinement_results_<YYYYMMDD>.jsonl # per-day run log
-    └── refinement_actions_*.txt            # optional; only when refinement path is taken
+    ├── refinement_actions_*.txt            # optional; only when refinement path is taken
+    ├── proposed_refinement_actions_*.txt    # CLI dry-run proposed actions
+    ├── proposed_refinement_review_*.md      # evidence-aware review report
+    └── proposed_refinement_review_*.json    # optional structured review report
 ```
 
 ### Agent-related commands
@@ -114,8 +122,29 @@ Run from your KB project root.
 | `deeprefine history list --pending` | Show unrefined queue |
 | `deeprefine loop init --query "..."` | Create `loop_trace_<id>.json` template |
 | `deeprefine loop validate --trace-file T` | Validate trace against Reafiner control flow |
-| `deeprefine apply --trace-file T --refinement-file F` | Apply `<refinement>` actions to `graph.json` |
+| `deeprefine review --trace-file T --refinement-file F` | Review proposed actions with HIGH/MEDIUM/LOW evidence labels; no graph write |
+| `deeprefine apply --trace-file T --refinement-file F` | Apply `<refinement>` actions to `graph.json` after approval; refuses LOW by default |
+| `deeprefine apply --allow-low-confidence --trace-file T --refinement-file F` | Override LOW-confidence guard explicitly |
 | `deeprefine loop finish --trace-file T [--refinement-file F]` | Persist results and mark history refined |
+
+### Evidence-aware review and safe apply
+
+`/deeprefine` should default to dry-run-first behavior. Proposed actions are reviewed before they can modify `graphify-out/graph.json`. Each action is labeled:
+
+| Label | Meaning |
+|-------|---------|
+| `HIGH` | Direct graph or code evidence exists. |
+| `MEDIUM` | k-hop context supports the action, but direct code or exact-edge evidence is missing. |
+| `LOW` | Node names are ambiguous, too broad, cross-community, or cannot be grounded in `graph.json`. |
+
+Bare function names such as `main()`, `run()`, `train()`, `test()`, and `setup()` are treated as ambiguous. Prefer file-qualified names:
+
+```text
+BAD:  insert_edge("main()", "calls", "Trainer")
+GOOD: insert_edge("pretraining/pretraining_CLIP_fine-grained.py::main()", "calls", "Trainer")
+```
+
+`deeprefine apply` refuses LOW-confidence actions by default. Use `--allow-low-confidence` only when the user explicitly accepts the risk.
 
 ---
 
@@ -157,11 +186,12 @@ cd /path/to/your-kb-project
 # Option A: import from graphify memory first (recommended)
 deeprefine history sync-memory
 deeprefine history list --pending
-deeprefine refine
+deeprefine refine          # dry-run: proposed actions + review, no graph write
+deeprefine refine --apply  # optional: write accepted CLI refine changes
 
 # Option B: add one explicit query
 deeprefine history add --query "your question"
-deeprefine refine
+deeprefine refine          # dry-run by default
 ```
 
 ### Terminal commands
@@ -172,8 +202,9 @@ deeprefine refine
 | `deeprefine history list` | List all history rows |
 | `deeprefine history sync-memory` | Import graphify memory queries into history |
 | `deeprefine history list --pending` | List only unrefined queries |
-| `deeprefine refine` | Refine all pending queries |
-| `deeprefine refine --query "..."` | Refine a single query (also records it) |
+| `deeprefine refine` | Generate proposed actions for all pending queries; dry-run by default |
+| `deeprefine refine --query "..."` | Generate proposed actions for a single query; dry-run by default |
+| `deeprefine refine --apply` | Persist accepted CLI refine changes to `graph.json` |
 | `deeprefine refine --rebuild-index` | Rebuild FAISS before refine |
 | `deeprefine index --rebuild` | Rebuild FAISS cache only |
 
@@ -183,12 +214,12 @@ deeprefine refine
 
 | Method | Command |
 |--------|---------|
-| **PyPI** | `pip install deeprefine-cli==0.1.7` |
+| **PyPI** | `pip install deeprefine-cli==0.1.8` |
 | **Source** | `pip install -e /path/to/DeepRefine-Skill` |
 
 ```bash
 deeprefine --help
-# Expect: cursor, history, index, refine, apply, loop
+# Expect: cursor, history, index, refine, review, apply, loop
 ```
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,11 +2,34 @@
 name: deeprefine
 description: >-
   Agent-native DeepRefine Reafiner loop — same control flow as Reafiner.refine(),
-  graphify search instead of FAISS, session LLM, deeprefine apply for graph writes.
+  graphify search instead of FAISS, session LLM, dry-run review before approved graph writes.
 disable-model-invocation: false
 ---
 
 # DeepRefine — Agent Reafiner loop (strict)
+
+## Default safety policy: dry-run only
+
+A normal `/deeprefine` invocation **MUST NEVER** call `deeprefine apply`.
+
+The default `/deeprefine` workflow must stop after:
+
+1. `deeprefine loop validate`
+2. `deeprefine review`
+3. showing the proposed actions and HIGH/MEDIUM/LOW review report to the user
+
+Then ask the user for explicit approval.
+
+Only if the user's **next message** explicitly says to approve/apply/write the graph may you run:
+
+```bash
+deeprefine apply --trace-file ... --refinement-file ...
+deeprefine loop finish --trace-file ... --refinement-file ...
+```
+
+Do not treat generation of `<refinement>` actions as approval. Do not treat a valid trace as approval. Do not apply in the same `/deeprefine` turn.
+
+---
 
 You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
 
@@ -14,7 +37,7 @@ You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepR
 |-----------|------------|-------------------------|
 | Retrieval | `graphify query` + k-hop from `graph.json` | FAISS retriever |
 | LLM | **Your session model** | External API / vLLM |
-| Graph writes | `deeprefine apply` + validated `loop_trace_*.json` | In-process |
+| Graph writes | Dry-run proposal + `deeprefine review`; `deeprefine apply` only after user approval | Dry-run by default; `--apply` persists |
 
 ---
 
@@ -24,12 +47,14 @@ Do **NOT**:
 
 1. Run `deeprefine refine` (unless the user explicitly asks for CLI/FAISS mode).
 2. Call `deeprefine apply` without a valid `loop_trace_<query_id>.json` (CLI will reject).
-3. Skip any hop’s `<judge>Yes</judge>` / `<judge>No</judge>` judgement.
-4. Skip error abduction when `len(interaction_history) > 1`.
-5. Write `<refinement>` before abduction when refinement is required.
-6. Hand-edit `graph.json` with Python or ad-hoc JSON patches.
-7. Ignore pending history and refine only one latest query when unrefined queries already exist.
-8. Invent a shorter pipeline (“read file → write refinement → apply”).
+3. Call `deeprefine apply` before running `deeprefine review` and receiving explicit user approval.
+4. Ignore LOW-confidence review warnings unless the user explicitly requests `--allow-low-confidence`.
+5. Skip any hop’s `<judge>Yes</judge>` / `<judge>No</judge>` judgement.
+6. Skip error abduction when `len(interaction_history) > 1`.
+7. Write `<refinement>` before abduction when refinement is required.
+8. Hand-edit `graph.json` with Python or ad-hoc JSON patches.
+9. Ignore pending history and refine only one latest query when unrefined queries already exist.
+10. Invent a shorter pipeline (“read file → write refinement → apply”).
 
 If validation fails, **fix the trace and re-run the missing step** — do not bypass with `--skip-trace-check`.
 
@@ -60,7 +85,7 @@ deeprefine loop init --query "<exact question>"
 ```
 
 Append each hop to `interaction_history` **before** starting the next hop.  
-Run `deeprefine loop validate --trace-file ...` after abduction and before `apply`.
+Run `deeprefine loop validate --trace-file ...` after abduction and before `review` / approved `apply`.
 
 ---
 
@@ -79,7 +104,7 @@ Run `deeprefine loop validate --trace-file ...` after abduction and before `appl
 3. If pending queue is non-empty: set `target_queries = pending_queue`.
 4. If pending queue is empty: set `target_queries = [current session question]`.
 5. Run the full Reafiner loop for **each** query in `target_queries`, one by one.
-6. Finish one query (`loop finish`) before starting the next query.
+6. For early-exit queries, finish immediately. For refinement-path queries, generate review output and wait for user approval before `apply` + `loop finish`.
 
 ---
 
@@ -146,11 +171,44 @@ for question in target_queries:
 
         save refinement to graphify-out/.deeprefine/refinement_actions_<id>.txt
         deeprefine loop validate --trace-file ... --refinement-file ...
-        deeprefine apply --trace-file ... --refinement-file ...
-        deeprefine loop finish --trace-file ... --refinement-file ...
+        deeprefine review --trace-file ... --refinement-file ...
+        SHOW review labels: HIGH / MEDIUM / LOW, evidence, warnings, suggested replacements
+        HARD STOP: do not modify graph.json in this /deeprefine turn
+        Report the proposed actions and HIGH/MEDIUM/LOW review to the user
+        Ask for explicit approval; approval must arrive in the user's next message
+
+        # Follow-up turn only, after the user's next message explicitly approves/apply/write:
+        if user explicitly approves and no LOW-confidence action remains:
+            deeprefine apply --trace-file ... --refinement-file ...
+            deeprefine loop finish --trace-file ... --refinement-file ...
+        if user explicitly accepts LOW-confidence risk in that approval message:
+            deeprefine apply --allow-low-confidence --trace-file ... --refinement-file ...
+            deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
 **Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+
+**Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
+
+---
+
+## Evidence-aware review rules
+
+Before any graph write, run:
+
+```bash
+deeprefine review --trace-file graphify-out/.deeprefine/loop_trace_<id>.json --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+```
+
+The review must label every action:
+
+- `HIGH`: direct graph or code evidence exists.
+- `MEDIUM`: k-hop context supports the action, but direct code or exact-edge evidence is missing.
+- `LOW`: endpoint nodes are ambiguous, too broad, cross-community, or cannot be grounded in `graph.json`.
+
+Bare names such as `main()`, `run()`, `train()`, `test()`, and `setup()` are ambiguous even if they match only one node. Prefer file-qualified labels such as `trainer_Brain_CLS.py::train_epoch()`.
+
+`deeprefine apply` refuses LOW-confidence actions by default. Use `--allow-low-confidence` only when the user explicitly approves the risk.
 
 ---
 
@@ -251,7 +309,9 @@ Copy and tick each item in your final message:
 [ ] Hops stopped on Yes OR reached MAX_HOPS
 [ ] early_exit OR (abduction + refinement) per Reafiner branch
 [ ] deeprefine loop validate passed
-[ ] deeprefine apply (only if refinement path)
+[ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
+[ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message
+[ ] deeprefine apply skipped in normal /deeprefine turn; only run after next-message approval
 [ ] deeprefine loop finish
 ```
 
@@ -281,12 +341,22 @@ deeprefine loop init --query "<question>"
 deeprefine loop validate --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
 deeprefine loop finish --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
 
-# 8b. Refinement path (len(history)>1)
+# 8b. Refinement path (len(history)>1): dry-run review first
 deeprefine loop validate --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+deeprefine review --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+
+# HARD STOP.
+# A normal /deeprefine run must end here.
+# Report the review to the user and ask for explicit approval.
+# Do NOT run deeprefine apply in the same /deeprefine turn.
+
+# Approval-only follow-up commands, only after the user explicitly says approve/apply:
 deeprefine apply --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+# Optional explicit risk override:
+# deeprefine apply --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 deeprefine loop finish --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 
-# 9. Repeat step 3..8 until all pending queries are finished.
+# 9. Repeat step 3..8 until all pending queries are reviewed/finished.
 ```
 
 ---
@@ -334,7 +404,8 @@ Only when the user **explicitly** requests `deeprefine refine` / full runtime:
 ```bash
 conda activate atlastune
 export DEEPREFINE_EMBED_URL=... DEEPREFINE_LLM_URL=...
-deeprefine refine --query "..."
+deeprefine refine --query "..."       # dry-run proposal only
+# deeprefine refine --query "..." --apply   # only when the user explicitly wants CLI mode to write graph.json
 ```
 
 ---
@@ -345,4 +416,6 @@ deeprefine refine --query "..."
 - `graphify-out/.deeprefine/loop_trace_*.json` (**required**)
 - `graphify-out/.deeprefine/refinement_actions_*.txt`
 - `graphify-out/.deeprefine/refinement_results_*.jsonl`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.md`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.json`
 - `graphify-out/.deeprefine/graph.json.bak`

--- a/deeprefine_skill/SKILL.md
+++ b/deeprefine_skill/SKILL.md
@@ -2,11 +2,34 @@
 name: deeprefine
 description: >-
   Agent-native DeepRefine Reafiner loop — same control flow as Reafiner.refine(),
-  graphify search instead of FAISS, session LLM, deeprefine apply for graph writes.
+  graphify search instead of FAISS, session LLM, dry-run review before approved graph writes.
 disable-model-invocation: false
 ---
 
 # DeepRefine — Agent Reafiner loop (strict)
+
+## Default safety policy: dry-run only
+
+A normal `/deeprefine` invocation **MUST NEVER** call `deeprefine apply`.
+
+The default `/deeprefine` workflow must stop after:
+
+1. `deeprefine loop validate`
+2. `deeprefine review`
+3. showing the proposed actions and HIGH/MEDIUM/LOW review report to the user
+
+Then ask the user for explicit approval.
+
+Only if the user's **next message** explicitly says to approve/apply/write the graph may you run:
+
+```bash
+deeprefine apply --trace-file ... --refinement-file ...
+deeprefine loop finish --trace-file ... --refinement-file ...
+```
+
+Do not treat generation of `<refinement>` actions as approval. Do not treat a valid trace as approval. Do not apply in the same `/deeprefine` turn.
+
+---
 
 You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
 
@@ -14,7 +37,7 @@ You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepR
 |-----------|------------|-------------------------|
 | Retrieval | `graphify query` + k-hop from `graph.json` | FAISS retriever |
 | LLM | **Your session model** | External API / vLLM |
-| Graph writes | `deeprefine apply` + validated `loop_trace_*.json` | In-process |
+| Graph writes | Dry-run proposal + `deeprefine review`; `deeprefine apply` only after user approval | Dry-run by default; `--apply` persists |
 
 ---
 
@@ -24,12 +47,14 @@ Do **NOT**:
 
 1. Run `deeprefine refine` (unless the user explicitly asks for CLI/FAISS mode).
 2. Call `deeprefine apply` without a valid `loop_trace_<query_id>.json` (CLI will reject).
-3. Skip any hop’s `<judge>Yes</judge>` / `<judge>No</judge>` judgement.
-4. Skip error abduction when `len(interaction_history) > 1`.
-5. Write `<refinement>` before abduction when refinement is required.
-6. Hand-edit `graph.json` with Python or ad-hoc JSON patches.
-7. Ignore pending history and refine only one latest query when unrefined queries already exist.
-8. Invent a shorter pipeline (“read file → write refinement → apply”).
+3. Call `deeprefine apply` before running `deeprefine review` and receiving explicit user approval.
+4. Ignore LOW-confidence review warnings unless the user explicitly requests `--allow-low-confidence`.
+5. Skip any hop’s `<judge>Yes</judge>` / `<judge>No</judge>` judgement.
+6. Skip error abduction when `len(interaction_history) > 1`.
+7. Write `<refinement>` before abduction when refinement is required.
+8. Hand-edit `graph.json` with Python or ad-hoc JSON patches.
+9. Ignore pending history and refine only one latest query when unrefined queries already exist.
+10. Invent a shorter pipeline (“read file → write refinement → apply”).
 
 If validation fails, **fix the trace and re-run the missing step** — do not bypass with `--skip-trace-check`.
 
@@ -60,7 +85,7 @@ deeprefine loop init --query "<exact question>"
 ```
 
 Append each hop to `interaction_history` **before** starting the next hop.  
-Run `deeprefine loop validate --trace-file ...` after abduction and before `apply`.
+Run `deeprefine loop validate --trace-file ...` after abduction and before `review` / approved `apply`.
 
 ---
 
@@ -79,7 +104,7 @@ Run `deeprefine loop validate --trace-file ...` after abduction and before `appl
 3. If pending queue is non-empty: set `target_queries = pending_queue`.
 4. If pending queue is empty: set `target_queries = [current session question]`.
 5. Run the full Reafiner loop for **each** query in `target_queries`, one by one.
-6. Finish one query (`loop finish`) before starting the next query.
+6. For early-exit queries, finish immediately. For refinement-path queries, generate review output and wait for user approval before `apply` + `loop finish`.
 
 ---
 
@@ -146,11 +171,44 @@ for question in target_queries:
 
         save refinement to graphify-out/.deeprefine/refinement_actions_<id>.txt
         deeprefine loop validate --trace-file ... --refinement-file ...
-        deeprefine apply --trace-file ... --refinement-file ...
-        deeprefine loop finish --trace-file ... --refinement-file ...
+        deeprefine review --trace-file ... --refinement-file ...
+        SHOW review labels: HIGH / MEDIUM / LOW, evidence, warnings, suggested replacements
+        HARD STOP: do not modify graph.json in this /deeprefine turn
+        Report the proposed actions and HIGH/MEDIUM/LOW review to the user
+        Ask for explicit approval; approval must arrive in the user's next message
+
+        # Follow-up turn only, after the user's next message explicitly approves/apply/write:
+        if user explicitly approves and no LOW-confidence action remains:
+            deeprefine apply --trace-file ... --refinement-file ...
+            deeprefine loop finish --trace-file ... --refinement-file ...
+        if user explicitly accepts LOW-confidence risk in that approval message:
+            deeprefine apply --allow-low-confidence --trace-file ... --refinement-file ...
+            deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
 **Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+
+**Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
+
+---
+
+## Evidence-aware review rules
+
+Before any graph write, run:
+
+```bash
+deeprefine review --trace-file graphify-out/.deeprefine/loop_trace_<id>.json --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+```
+
+The review must label every action:
+
+- `HIGH`: direct graph or code evidence exists.
+- `MEDIUM`: k-hop context supports the action, but direct code or exact-edge evidence is missing.
+- `LOW`: endpoint nodes are ambiguous, too broad, cross-community, or cannot be grounded in `graph.json`.
+
+Bare names such as `main()`, `run()`, `train()`, `test()`, and `setup()` are ambiguous even if they match only one node. Prefer file-qualified labels such as `trainer_Brain_CLS.py::train_epoch()`.
+
+`deeprefine apply` refuses LOW-confidence actions by default. Use `--allow-low-confidence` only when the user explicitly approves the risk.
 
 ---
 
@@ -251,7 +309,9 @@ Copy and tick each item in your final message:
 [ ] Hops stopped on Yes OR reached MAX_HOPS
 [ ] early_exit OR (abduction + refinement) per Reafiner branch
 [ ] deeprefine loop validate passed
-[ ] deeprefine apply (only if refinement path)
+[ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
+[ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message
+[ ] deeprefine apply skipped in normal /deeprefine turn; only run after next-message approval
 [ ] deeprefine loop finish
 ```
 
@@ -281,12 +341,22 @@ deeprefine loop init --query "<question>"
 deeprefine loop validate --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
 deeprefine loop finish --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
 
-# 8b. Refinement path (len(history)>1)
+# 8b. Refinement path (len(history)>1): dry-run review first
 deeprefine loop validate --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+deeprefine review --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+
+# HARD STOP.
+# A normal /deeprefine run must end here.
+# Report the review to the user and ask for explicit approval.
+# Do NOT run deeprefine apply in the same /deeprefine turn.
+
+# Approval-only follow-up commands, only after the user explicitly says approve/apply:
 deeprefine apply --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+# Optional explicit risk override:
+# deeprefine apply --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 deeprefine loop finish --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 
-# 9. Repeat step 3..8 until all pending queries are finished.
+# 9. Repeat step 3..8 until all pending queries are reviewed/finished.
 ```
 
 ---
@@ -334,7 +404,8 @@ Only when the user **explicitly** requests `deeprefine refine` / full runtime:
 ```bash
 conda activate atlastune
 export DEEPREFINE_EMBED_URL=... DEEPREFINE_LLM_URL=...
-deeprefine refine --query "..."
+deeprefine refine --query "..."       # dry-run proposal only
+# deeprefine refine --query "..." --apply   # only when the user explicitly wants CLI mode to write graph.json
 ```
 
 ---
@@ -345,4 +416,6 @@ deeprefine refine --query "..."
 - `graphify-out/.deeprefine/loop_trace_*.json` (**required**)
 - `graphify-out/.deeprefine/refinement_actions_*.txt`
 - `graphify-out/.deeprefine/refinement_results_*.jsonl`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.md`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.json`
 - `graphify-out/.deeprefine/graph.json.bak`

--- a/deeprefine_skill/action_review.py
+++ b/deeprefine_skill/action_review.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .agent_graph import _parse_action_string, parse_refinement_block
+
+
+AMBIGUOUS_LABELS = {
+    "main",
+    "main()",
+    "run",
+    "run()",
+    "train",
+    "train()",
+    "test",
+    "test()",
+    "setup",
+    "setup()",
+}
+
+
+@dataclass
+class ActionReview:
+    action: str
+    confidence: str
+    evidence: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    suggested_replacement: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "confidence": self.confidence,
+            "evidence": self.evidence,
+            "warnings": self.warnings,
+            "suggested_replacement": self.suggested_replacement,
+        }
+
+
+def _label(node: dict[str, Any]) -> str:
+    return str(node.get("label") or node.get("id") or "")
+
+
+def _node_source(node: dict[str, Any]) -> str | None:
+    src = node.get("source_file") or node.get("file_id") or node.get("source_url")
+    return str(src) if src else None
+
+
+def _all_node_names(node: dict[str, Any]) -> set[str]:
+    names = {_label(node), str(node.get("id") or "")}
+    names.update(str(a) for a in node.get("aliases") or [])
+    return {n.strip() for n in names if n and n.strip()}
+
+
+def _split_qualified_label(name: str) -> tuple[str | None, str]:
+    if "::" not in name:
+        return None, name
+    src, label = name.rsplit("::", 1)
+    return src.strip() or None, label.strip()
+
+
+def _source_matches(node: dict[str, Any], src: str | None) -> bool:
+    if not src:
+        return True
+    node_src = _node_source(node)
+    if not node_src:
+        return False
+    node_src = node_src.replace("\\", "/").strip()
+    src = src.replace("\\", "/").strip()
+    return node_src == src or node_src.endswith("/" + src) or src.endswith("/" + node_src)
+
+
+def _matching_nodes(nodes: list[dict[str, Any]], name: str) -> list[dict[str, Any]]:
+    query_src, query_label = _split_qualified_label(name.strip())
+    target = query_label.casefold()
+    return [
+        n
+        for n in nodes
+        if _source_matches(n, query_src)
+        and target in {x.casefold() for x in _all_node_names(n)}
+    ]
+
+
+def _function_tail(name: str) -> str | None:
+    stripped = name.strip()
+    if "::" in stripped:
+        stripped = stripped.rsplit("::", 1)[-1]
+    if stripped.endswith("()"):
+        return stripped
+    return None
+
+
+def _candidate_qualified_nodes(nodes: list[dict[str, Any]], bare_name: str) -> list[dict[str, Any]]:
+    tail = _function_tail(bare_name)
+    if not tail:
+        return []
+    out: list[dict[str, Any]] = []
+    for n in nodes:
+        names = _all_node_names(n)
+        if any(x.endswith(f"::{tail}") or x.endswith(f".{tail}") for x in names):
+            out.append(n)
+    return out
+
+
+def _candidate_labels(candidates: list[dict[str, Any]]) -> list[str]:
+    labels = sorted({_format_node(n) for n in candidates})
+    return labels[:3]
+
+
+def _links(raw: dict[str, Any]) -> list[dict[str, Any]]:
+    return list(raw.get("links") or raw.get("edges") or [])
+
+
+def _edge_exists(
+    raw: dict[str, Any],
+    subject_nodes: list[dict[str, Any]],
+    relation: str,
+    object_nodes: list[dict[str, Any]],
+) -> bool:
+    subject_ids = {str(n.get("id")) for n in subject_nodes}
+    object_ids = {str(n.get("id")) for n in object_nodes}
+    for link in _links(raw):
+        if (
+            str(link.get("source")) in subject_ids
+            and str(link.get("target")) in object_ids
+            and str(link.get("relation") or link.get("label") or "") == relation
+        ):
+            return True
+    return False
+
+
+def _code_token(name: str) -> str:
+    token = name.strip().split("::")[-1].split(".")[-1]
+    token = token[:-2] if token.endswith("()") else token
+    return token.strip()
+
+
+def _source_files_for(nodes: list[dict[str, Any]], project_root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for node in nodes:
+        src = _node_source(node)
+        if not src or src.startswith(("http://", "https://")):
+            continue
+        path = Path(src)
+        if not path.is_absolute():
+            path = project_root / path
+        if path.is_file() and path not in paths:
+            paths.append(path)
+    return paths
+
+
+def _has_code_evidence(path: Path, subject: str, relation: str, obj: str) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    sub_token = _code_token(subject)
+    obj_token = _code_token(obj)
+    rel = relation.strip().casefold()
+    if not obj_token:
+        return False
+
+    if rel in {"method", "has_method", "defines", "contains"}:
+        class_match = re.search(rf"\bclass\s+{re.escape(sub_token)}\b", text) if sub_token else None
+        method_match = re.search(rf"\b(def|async\s+def)\s+{re.escape(obj_token)}\b", text)
+        return bool(class_match and method_match)
+
+    if rel in {"calls", "call", "uses", "instantiates"}:
+        sub_defined = bool(
+            sub_token
+            and re.search(rf"\b(class|def|async\s+def)\s+{re.escape(sub_token)}\b", text)
+        )
+        obj_called = bool(re.search(rf"\b{re.escape(obj_token)}\s*\(", text))
+        return sub_defined and obj_called
+
+    if rel in {"imports", "import", "from_imports"}:
+        return bool(re.search(rf"\b(import|from)\b[^\n]*\b{re.escape(obj_token)}\b", text))
+
+    return False
+
+
+def _format_node(node: dict[str, Any]) -> str:
+    src = _node_source(node)
+    label = _label(node)
+    return f"{src}::{label}" if src and "::" not in label else label
+
+
+def _display_path(path: Path, project_root: Path) -> str:
+    try:
+        return str(path.relative_to(project_root))
+    except ValueError:
+        return str(path)
+
+
+def _action_with_args(fn: str, args: list[str]) -> str:
+    quoted = ", ".join(json.dumps(a, ensure_ascii=False) for a in args)
+    return f"{fn}({quoted})"
+
+
+def _suggest_disambiguation(
+    raw: dict[str, Any], fn: str, args: list[str], ambiguous_arg_indexes: list[int]
+) -> str | None:
+    nodes = list(raw.get("nodes") or [])
+    new_args = list(args)
+    changed = False
+    for idx in ambiguous_arg_indexes:
+        candidates = _matching_nodes(nodes, args[idx]) or _candidate_qualified_nodes(nodes, args[idx])
+        if candidates:
+            ranked = sorted(candidates, key=lambda n: (_node_source(n) or "", _label(n)))
+            new_args[idx] = _format_node(ranked[0])
+            changed = True
+    return _action_with_args(fn, new_args) if changed else None
+
+
+def review_action(raw: dict[str, Any], action: str, *, project_root: Path | None = None) -> ActionReview:
+    nodes = list(raw.get("nodes") or [])
+    try:
+        fn, args = _parse_action_string(action)
+    except ValueError as exc:
+        return ActionReview(
+            action=action,
+            confidence="LOW",
+            warnings=[str(exc)],
+        )
+
+    evidence: list[str] = []
+    warnings: list[str] = []
+    ambiguous_arg_indexes: list[int] = []
+
+    entity_indexes = [0, 2] if fn in {"insert_edge", "delete_edge"} else [0, 1]
+    for idx in entity_indexes:
+        if idx >= len(args):
+            continue
+        name = args[idx]
+        query_src, query_label = _split_qualified_label(name.strip())
+        is_generic_bare_name = query_src is None and query_label.casefold() in AMBIGUOUS_LABELS
+        matches = _matching_nodes(nodes, name)
+        qualified_candidates = _candidate_qualified_nodes(nodes, name)
+        if matches:
+            sources = sorted({s for n in matches if (s := _node_source(n))})
+            evidence.append(f"Node exists: {name}" + (f" ({', '.join(sources[:3])})" if sources else ""))
+        if is_generic_bare_name:
+            warnings.append(f"Ambiguous bare node name: {name!r}; include file or module path.")
+            ambiguous_arg_indexes.append(idx)
+        if len(matches) > 1:
+            warnings.append(f"Ambiguous node name: {name!r} matches {len(matches)} graph nodes.")
+            warnings.append("Candidate qualified names: " + "; ".join(_candidate_labels(matches)))
+            if idx not in ambiguous_arg_indexes:
+                ambiguous_arg_indexes.append(idx)
+        elif not matches and len(qualified_candidates) > 1:
+            warnings.append(
+                f"Ambiguous function name: {name!r} has {len(qualified_candidates)} qualified candidates."
+            )
+            warnings.append(
+                "Candidate qualified names: " + "; ".join(_candidate_labels(qualified_candidates))
+            )
+            if idx not in ambiguous_arg_indexes:
+                ambiguous_arg_indexes.append(idx)
+
+    if fn in {"insert_edge", "delete_edge"} and len(args) >= 3:
+        sub_matches = _matching_nodes(nodes, args[0])
+        obj_matches = _matching_nodes(nodes, args[2])
+        if _edge_exists(raw, sub_matches, args[1], obj_matches):
+            evidence.append("Exact edge already exists in graph.json.")
+        elif sub_matches and obj_matches:
+            evidence.append("Both endpoint nodes exist in graph.json; relation is inferred by refinement loop.")
+        if project_root and sub_matches:
+            for path in _source_files_for(sub_matches, project_root):
+                if _has_code_evidence(path, args[0], args[1], args[2]):
+                    evidence.append(f"Direct code evidence in {_display_path(path, project_root)}.")
+                    break
+
+    if fn == "replace_node" and len(args) >= 2:
+        old_matches = _matching_nodes(nodes, args[0])
+        if old_matches:
+            evidence.append("Replacement source node exists in graph.json.")
+        if _matching_nodes(nodes, args[1]):
+            evidence.append("Replacement target node already exists in graph.json.")
+
+    suggested = _suggest_disambiguation(raw, fn, args, ambiguous_arg_indexes)
+
+    if warnings:
+        confidence = "LOW"
+    elif any(
+        "Exact edge already exists" in e
+        or "Replacement source node" in e
+        or "Direct code evidence" in e
+        for e in evidence
+    ):
+        confidence = "HIGH"
+    elif evidence:
+        confidence = "MEDIUM"
+    else:
+        confidence = "LOW"
+        warnings.append("No direct node or edge evidence found in graph.json.")
+
+    return ActionReview(
+        action=action,
+        confidence=confidence,
+        evidence=evidence,
+        warnings=warnings,
+        suggested_replacement=suggested,
+    )
+
+
+def review_refinement_text(
+    raw: dict[str, Any], refinement_text: str, *, project_root: Path | None = None
+) -> list[ActionReview]:
+    return [
+        review_action(raw, action, project_root=project_root)
+        for action in parse_refinement_block(refinement_text)
+    ]
+
+
+def render_review_markdown(reviews: list[ActionReview]) -> str:
+    lines = [f"DeepRefine proposed {len(reviews)} refinement action(s).", ""]
+    for review in reviews:
+        lines.append(f"[{review.confidence}] {review.action}")
+        if review.evidence:
+            lines.append("Evidence:")
+            lines.extend(f"- {item}" for item in review.evidence)
+        if review.warnings:
+            lines.append("Warning:")
+            lines.extend(f"- {item}" for item in review.warnings)
+        if review.suggested_replacement:
+            lines.append("Suggested replacement:")
+            lines.append(f"- {review.suggested_replacement}")
+        lines.append("")
+    lines.append("Apply only after review: deeprefine apply --trace-file <trace> --refinement-file <actions>")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_review_files(
+    *,
+    graph_path: Path,
+    refinement_text: str,
+    report_path: Path,
+    json_path: Path | None = None,
+) -> tuple[list[ActionReview], str]:
+    raw = json.loads(graph_path.read_text(encoding="utf-8"))
+    project_root = graph_path.parent.parent if graph_path.parent.name == "graphify-out" else None
+    reviews = review_refinement_text(raw, refinement_text, project_root=project_root)
+    markdown = render_review_markdown(reviews)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(markdown, encoding="utf-8")
+    if json_path:
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(
+            json.dumps([r.to_dict() for r in reviews], ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    return reviews, markdown

--- a/deeprefine_skill/agent_graph.py
+++ b/deeprefine_skill/agent_graph.py
@@ -13,9 +13,32 @@ def _norm_label(s: str) -> str:
     return unicodedata.normalize("NFKC", s.strip()).casefold()
 
 
+def _split_qualified_label(label: str) -> tuple[str | None, str]:
+    if "::" not in label:
+        return None, label
+    src, name = label.rsplit("::", 1)
+    return src.strip() or None, name.strip()
+
+
+def _same_source(node_src: str | None, query_src: str | None) -> bool:
+    if not node_src or not query_src:
+        return False
+    node_src = node_src.replace("\\", "/").strip()
+    query_src = query_src.replace("\\", "/").strip()
+    return (
+        node_src == query_src
+        or node_src.endswith("/" + query_src)
+        or query_src.endswith("/" + node_src)
+    )
+
+
 def _find_node_id_by_label(nodes: list[dict[str, Any]], label: str) -> str | None:
-    target = _norm_label(label)
+    query_src, query_label = _split_qualified_label(label)
+    target = _norm_label(query_label)
     for n in nodes:
+        node_src = n.get("source_file") or n.get("file_id") or n.get("source_url")
+        if query_src and not _same_source(str(node_src) if node_src else None, query_src):
+            continue
         if _norm_label(n.get("label", "")) == target:
             return n["id"]
         for alias in n.get("aliases") or []:

--- a/deeprefine_skill/cli.py
+++ b/deeprefine_skill/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -117,6 +118,7 @@ def cmd_index(args: argparse.Namespace) -> int:
 def cmd_apply(args: argparse.Namespace) -> int:
     """Apply <refinement> actions (from agent loop) to graph.json."""
     from deeprefine_skill.agent_loop import load_trace, validate_trace
+    from deeprefine_skill.action_review import render_review_markdown, review_refinement_text
 
     project = find_project_root(Path(args.project_root) if args.project_root else None)
     paths = graphify_paths(project)
@@ -141,6 +143,20 @@ def cmd_apply(args: argparse.Namespace) -> int:
                 print(f"  - {e}", file=sys.stderr)
             return 1
 
+    raw = json.loads(paths["graph_json"].read_text(encoding="utf-8"))
+    reviews = review_refinement_text(raw, text, project_root=project)
+    print(render_review_markdown(reviews))
+    low_confidence = [review for review in reviews if review.confidence == "LOW"]
+    if low_confidence and not args.allow_low_confidence:
+        print(
+            "Refusing to apply because LOW-confidence action(s) were detected. "
+            "Review or rewrite the proposed actions, or rerun with --allow-low-confidence to override.",
+            file=sys.stderr,
+        )
+        for review in low_confidence:
+            print(f"  - {review.action}", file=sys.stderr)
+        return 1
+
     backup = paths["graph_backup"]
     if paths["graph_json"].is_file() and not backup.is_file():
         backup.parent.mkdir(parents=True, exist_ok=True)
@@ -153,6 +169,40 @@ def cmd_apply(args: argparse.Namespace) -> int:
     print(f"Applied {len(changes)} action(s) to {paths['graph_json']}")
     for c in changes:
         print(f"  - {c}")
+    return 0
+
+
+def cmd_review(args: argparse.Namespace) -> int:
+    """Validate and render evidence-aware proposed refinement actions."""
+    from deeprefine_skill.action_review import write_review_files
+    from deeprefine_skill.agent_loop import load_trace, validate_trace
+
+    project = find_project_root(Path(args.project_root) if args.project_root else None)
+    paths = graphify_paths(project)
+    text = Path(args.refinement_file).read_text(encoding="utf-8")
+
+    if args.trace_file:
+        trace = load_trace(Path(args.trace_file))
+        errs = validate_trace(trace, refinement_text=text)
+        if errs:
+            print("Loop trace validation failed:", file=sys.stderr)
+            for e in errs:
+                print(f"  - {e}", file=sys.stderr)
+            return 1
+
+    report_path = Path(args.output) if args.output else paths["graphify_out"] / ".deeprefine" / "proposed_refinement_review.md"
+    json_path = Path(args.json_output) if args.json_output else None
+    reviews, markdown = write_review_files(
+        graph_path=paths["graph_json"],
+        refinement_text=text,
+        report_path=report_path,
+        json_path=json_path,
+    )
+    print(markdown)
+    print(f"Review saved: {report_path}")
+    if json_path:
+        print(f"Review JSON saved: {json_path}")
+    print(f"No graph changes applied. Proposed actions: {len(reviews)}")
     return 0
 
 
@@ -261,11 +311,22 @@ def cmd_refine(args: argparse.Namespace) -> int:
         cfg,
         query=args.query,
         rebuild_index=args.rebuild_index,
+        apply=args.apply,
     )
     print("\n--- DeepRefine summary ---")
+    print(f"Mode: {result['mode']}")
     print(f"Queries processed: {result['queries_processed']}")
     print(f"Graph: {result['graph_path']} ({result['nodes']} nodes, {result['edges']} edges)")
     print(f"Log: {result['log_path']}")
+    if result["mode"] == "dry-run":
+        print("No graph changes applied. Review proposed actions, then run deeprefine apply if approved.")
+    for row in result.get("summary", []):
+        if row.get("action_file") or row.get("review_file"):
+            print(f"Proposal [{row['id']}]:")
+            if row.get("action_file"):
+                print(f"  actions: {row['action_file']}")
+            if row.get("review_file"):
+                print(f"  review: {row['review_file']}")
     return 0
 
 
@@ -348,7 +409,23 @@ def main(argv: list[str] | None = None) -> int:
     p_refine.add_argument("--query", default=None, help="Single query (also recorded)")
     p_refine.add_argument("--project-root", default=None)
     p_refine.add_argument("--rebuild-index", action="store_true")
+    p_refine.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write accepted CLI refine changes to graph.json. Default is dry-run proposal only.",
+    )
     p_refine.set_defaults(func=cmd_refine)
+
+    p_review = sub.add_parser(
+        "review",
+        help="Validate and show proposed <refinement> actions without changing graph.json",
+    )
+    p_review.add_argument("--refinement-file", required=True)
+    p_review.add_argument("--trace-file", required=False)
+    p_review.add_argument("--output", default=None, help="Markdown report path")
+    p_review.add_argument("--json-output", default=None, help="Optional JSON report path")
+    p_review.add_argument("--project-root", default=None)
+    p_review.set_defaults(func=cmd_review)
 
     p_apply = sub.add_parser(
         "apply",
@@ -368,6 +445,11 @@ def main(argv: list[str] | None = None) -> int:
         "--skip-trace-check",
         action="store_true",
         help="Bypass loop validation (not for /deeprefine agent mode)",
+    )
+    p_apply.add_argument(
+        "--allow-low-confidence",
+        action="store_true",
+        help="Apply even when the review contains LOW-confidence actions.",
     )
     p_apply.add_argument("--project-root", default=None)
     p_apply.set_defaults(func=cmd_apply)

--- a/deeprefine_skill/refine_runner.py
+++ b/deeprefine_skill/refine_runner.py
@@ -17,6 +17,7 @@ from .adapter_graphify import (
     save_graphify_json,
     sync_kg_to_graphify,
 )
+from .action_review import write_review_files
 from .history import append_history, mark_refined, query_id
 
 
@@ -105,6 +106,7 @@ def run_refine(
     rebuild_index: bool = False,
     base_top_k: int = 5,
     max_hops: int = 4,
+    apply: bool = False,
 ) -> dict[str, Any]:
     if not graph_path.is_file():
         raise FileNotFoundError(f"graphify graph not found: {graph_path}")
@@ -113,6 +115,7 @@ def run_refine(
     raw, data = load_or_build_data(
         graph_path, cache_pkl, encoder, rebuild=rebuild_index
     )
+    original_kg = data["KG"].copy()
 
     reafiner = Reafiner(
         data=data,
@@ -134,6 +137,8 @@ def run_refine(
 
     def _persist() -> None:
         if completed == 0:
+            return
+        if not apply:
             return
         data["KG"] = reafiner.kg
         nonlocal raw
@@ -166,12 +171,38 @@ def run_refine(
                         "action_count": rr.get("refinement_action_count", 0),
                     }
                 )
-                refined_ids.add(qid)
+                if apply:
+                    refined_ids.add(qid)
                 completed += 1
+                action_file = None
+                review_file = None
+                review_count = 0
+                if rr.get("refinement_action_raw"):
+                    action_file = log_dir / f"proposed_refinement_actions_{qid}.txt"
+                    review_file = log_dir / f"proposed_refinement_review_{qid}.md"
+                    action_file.write_text(rr["refinement_action_raw"], encoding="utf-8")
+                    reviews, _ = write_review_files(
+                        graph_path=graph_path,
+                        refinement_text=rr["refinement_action_raw"],
+                        report_path=review_file,
+                        json_path=log_dir / f"proposed_refinement_review_{qid}.json",
+                    )
+                    review_count = len(reviews)
+                    summary_rows[-1]["action_file"] = str(action_file)
+                    summary_rows[-1]["review_file"] = str(review_file)
+                    summary_rows[-1]["mode"] = "apply" if apply else "dry-run"
                 print(
                     f"  steps={n_steps}, nodes={reafiner.kg.number_of_nodes()}, "
                     f"edges={reafiner.kg.number_of_edges()}"
                 )
+                if action_file and review_file:
+                    print(
+                        f"  proposed_actions={review_count}, action_file={action_file}, "
+                        f"review={review_file}"
+                    )
+                if not apply:
+                    data["KG"] = original_kg.copy()
+                    reafiner.kg = data["KG"]
     finally:
         _persist()
 
@@ -181,6 +212,7 @@ def run_refine(
         "nodes": reafiner.kg.number_of_nodes(),
         "edges": reafiner.kg.number_of_edges(),
         "queries_processed": len(queries),
+        "mode": "apply" if apply else "dry-run",
         "summary": summary_rows,
     }
 
@@ -191,6 +223,7 @@ def refine_from_history(
     *,
     query: str | None = None,
     rebuild_index: bool = False,
+    apply: bool = False,
 ) -> dict[str, Any]:
     if query:
         entry = append_history(paths["history"], query, source="deeprefine")
@@ -215,4 +248,5 @@ def refine_from_history(
         cfg=cfg,
         queries=queries,
         rebuild_index=rebuild_index,
+        apply=apply,
     )


### PR DESCRIPTION
This PR improves the safety and usability of DeepRefine-Skill by adding an evidence-aware review workflow before applying graph updates.

Motivation

The current `/deeprefine` workflow may directly apply generated refinement actions to `graphify-out/graph.json`. Since these actions are inferred by the agent, some edges may be uncertain, ambiguous, or weakly grounded. Applying them without review can potentially pollute the Graphify knowledge graph.

This PR changes the workflow to review proposed actions before writing them into the graph.

Changes

* Add `deeprefine_skill/action_review.py` for evidence-aware action review
* Add `deeprefine review --trace-file ... --refinement-file ...`
* Generate review reports for proposed refinement actions without modifying `graph.json`
* Label each proposed action as `HIGH`, `MEDIUM`, or `LOW` confidence
* Include evidence, warnings, and suggested replacements in the review output
* Treat generic bare node names such as `main()`, `run()`, `train()`, `test()`, and `setup()` as ambiguous
* Support source-qualified node names such as `trainer_Brain_CLS.py::train_epoch()`
* Prevent source-qualified names from creating duplicate graph nodes during apply
* Make `deeprefine apply` refuse `LOW`-confidence actions by default
* Add `--allow-low-confidence` as an explicit override
* Update README and SKILL.md to document the safer workflow

