### PR TITLE
Opencode适配

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 # Personal working documents — kept locally, not distributed
 docs/tmp/
 CLAUDE.local.md
+".omo/" 
+"graphify-out/" 
+"venv/" 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ build/
 # Personal working documents — kept locally, not distributed
 docs/tmp/
 CLAUDE.local.md
-".omo/" 
-"graphify-out/" 
-"venv/" 
+.omo/
+graphify-out/
+venv/ 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 </div>
 
-DeepRefine-Skill plugs into agent workflows and use a single command `/deeprefine` in your agent CLI to refine and evolve your LLM-Wiki (e.g., **[graphify](https://github.com/safishamsi/graphify)**) knowledge base.
+DeepRefine-Skill plugs into agent workflows and use a single command `/deeprefine` in your agent (Cursor, Copilot CLI, Gemini CLI, Codex, OpenCode) to refine and evolve your LLM-Wiki (e.g., **[graphify](https://github.com/safishamsi/graphify)**) knowledge base.
 
 <p align="center">
 <img src="assets/demo-typing-deeprefine.svg" alt="Demo: /deeprefine" />
@@ -422,6 +422,72 @@ deeprefine refine          # dry-run by default
 
 
 
+## OpenCode Integration
+
+### Prerequisites
+
+- **OpenCode CLI** installed and configured
+- **graphify** CLI available on your PATH
+- **Python 3.10+** with `deeprefine-cli` installed
+- A `graphify-out/graph.json` knowledge graph in your project
+
+### Setup
+
+```bash
+# Install into the current project
+deeprefine opencode install --project
+
+# Install globally (all projects)
+deeprefine opencode install --user
+```
+
+This installs **4 files**:
+
+| Destination | Source | Purpose |
+|------------|--------|---------|
+| `.opencode/skills/deeprefine/SKILL.md` | `SKILL_OPENCODE.md` | Agent harness with 6 OpenCode-native optimizations |
+| `.opencode/commands/deeprefine.md` | `commands/opencode/deeprefine.md` | Full workflow entrypoint (`/deeprefine`) |
+| `.opencode/commands/deeprefine-review.md` | `commands/opencode/deeprefine-review.md` | Review-only entrypoint (`/deeprefine-review`) |
+| `.opencode/commands/deeprefine-apply.md` | `commands/opencode/deeprefine-apply.md` | Apply-only entrypoint (`/deeprefine-apply`) |
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `/deeprefine` | Full pipeline: sync → judge → abduction → refinement → 5-Oracle review → (await approval) → apply → post-apply verify |
+| `/deeprefine-review` | Review only: read existing actions → 5-Oracle audit → evidence review → present results |
+| `/deeprefine-apply` | Apply only: read reviewed actions → confirm → apply → post-apply verify → finish |
+
+### Model Configuration
+
+OpenCode supports per-phase model routing via environment variables:
+
+| Variable | Phase | Purpose |
+|----------|-------|---------|
+| `DEEPREFINE_JUDGE_MODEL` | Judgement (`<judge>Yes/No</judge>`) | Fast, cheap model for binary classification (e.g., `gpt-4o-mini`) |
+| `DEEPREFINE_REFINE_MODEL` | Abduction + Refinement | Strong reasoning model for complex causal analysis (e.g., `claude-sonnet-4-20250514`) |
+
+If either variable is unset, the session default model is used.
+
+### OpenCode-Native Optimizations
+
+DeepRefine on OpenCode includes 6 platform-native optimizations not available in Cursor or Cline:
+
+1. **Parallel query processing** — Multiple pending queries are dispatched to parallel subagents via `task()`, reducing wall-clock time to ~1 query's duration
+2. **Phase-specific model routing** — Binary judgement uses a cheap model; complex abduction/refinement uses a strong model
+3. **Structured progress tracking** — `todowrite()` replaces text checklists, enabling real-time progress visibility and cross-session resumption
+4. **5-Oracle parallel review** — Five specialized oracle subagents audit refinement actions from orthogonal angles (completeness, correctness, safety, consistency, edge-cases) before any graph mutation
+5. **Post-apply auto-verification** — After applying refinement actions, the original query is re-run to confirm the graph fix actually resolved the issue
+6. **Evidence ledger** — Every phase boundary writes a structured JSONL entry (`graphify-out/.deeprefine/ledger.jsonl`) with timestamps, artifacts, and QA results for full auditability
+
+### Uninstall
+
+```bash
+deeprefine opencode uninstall --project
+```
+
+
+
 ## Installation
 
 | Method | Command |
@@ -431,7 +497,7 @@ deeprefine refine          # dry-run by default
 
 ```bash
 deeprefine --help
-# Expect: cursor, copilot, codex, gemini, history, index, refine, review, apply, loop
+# Expect: cursor, copilot, codex, opencode, gemini, history, index, refine, review, apply, loop
 ```
 </details>
 

--- a/deeprefine_skill/SKILL_OPENCODE.md
+++ b/deeprefine_skill/SKILL_OPENCODE.md
@@ -1,0 +1,684 @@
+---
+name: deeprefine
+description: "Agent-native DeepRefine Reafiner loop for Graphify knowledge graphs with 6 OpenCode-native optimizations — parallel query processing, phase-specific model routing, structured progress tracking, 5-oracle parallel review, post-apply verification, and evidence ledger."
+---
+
+# DeepRefine — Agent Reafiner loop (OpenCode optimized)
+
+## Default safety policy: dry-run only
+
+A normal `/deeprefine` invocation **MUST NEVER** call `deeprefine apply`.
+
+The default `/deeprefine` workflow must stop after:
+
+1. `deeprefine loop validate`
+2. `deeprefine review` (including 5-oracle parallel audit)
+3. showing the proposed actions and HIGH/MEDIUM/LOW review report to the user
+
+Then ask the user for explicit approval.
+
+Only if the user's **next message** explicitly says to approve/apply/write the graph may you run:
+
+```bash
+deeprefine apply --trace-file ... --refinement-file ...
+deeprefine loop finish --trace-file ... --refinement-file ...
+```
+
+Do not treat generation of `<refinement>` actions as approval. Do not treat a valid trace as approval. Do not apply in the same `/deeprefine` turn.
+
+---
+
+## OpenCode-native optimizations (what's different from Cursor)
+
+This harness leverages 6 OpenCode platform capabilities unavailable in Cursor or Cline:
+
+| # | Optimization | OpenCode Capability | Impact |
+|---|-------------|---------------------|--------|
+| 1 | **Parallel query processing** | `task()` subagent fan-out | N queries complete in ~1 query's wall-clock time |
+| 2 | **Phase-specific model routing** | env-var model selection | Cheap model for binary judgement; strong model for abduction/refinement |
+| 3 | **Structured progress tracking** | `todowrite()` | Real-time progress; agent resumes from last completed phase |
+| 4 | **5-Oracle parallel review** | `task(subagent_type="general")` × 5 | Orthogonal quality audit — all 5 must APPROVE before apply |
+| 5 | **Post-apply auto-verification** | graphify re-query after apply | Confirms the graph mutation actually fixed the issue |
+| 6 | **Evidence ledger** | JSONL append to disk | Full audit trail: every phase with timestamp, artifacts, QA results |
+
+---
+
+You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
+
+| Component | Agent mode | CLI `deeprefine refine` |
+|-----------|------------|-------------------------|
+| Retrieval | `graphify query` + k-hop from `graph.json` | FAISS retriever |
+| LLM | **OpenCode session model** (routed per phase) | External API / vLLM |
+| Graph writes | Dry-run proposal + `deeprefine review` + 5-Oracle audit; `deeprefine apply` only after user approval | Dry-run by default; `--apply` persists |
+
+---
+
+## Model routing
+
+OpenCode supports per-phase model selection via environment variables:
+
+- **Judgement phase** (`<judge>Yes|No</judge>`): Set `$DEEPREFINE_JUDGE_MODEL` — preference for fast, cheap models (e.g., `gpt-4o-mini`, `claude-haiku`). Binary classification doesn't need frontier intelligence.
+- **Abduction + Refinement phase**: Set `$DEEPREFINE_REFINE_MODEL` — preference for strong reasoning models (e.g., `claude-opus`, `gpt-4o`, `deepseek-v3`). Complex causal reasoning about graph structure errors.
+
+If either env var is unset, the session default model is used.
+
+When invoking LLM calls in the workflow, prefer the phase-appropriate model. The `/deeprefine-*` commands bind `${DEEPREFINE_REFINE_MODEL}` by default; override per-command with env vars.
+
+---
+
+## FORBIDDEN (hard stop)
+
+Do **NOT**:
+
+1. Run `deeprefine refine` (unless the user explicitly asks for CLI/FAISS mode).
+2. Call `deeprefine apply` without a valid `loop_trace_<query_id>.json` (CLI will reject).
+3. Call `deeprefine apply` before running `deeprefine review` + 5-Oracle audit and receiving explicit user approval.
+4. Call `deeprefine apply` before all 5 Oracle subagents return APPROVE (or user explicitly overrides).
+5. Ignore LOW-confidence review warnings unless the user explicitly requests `--allow-low-confidence`.
+6. Skip any hop's `<judge>Yes</judge>` / `<judge>No</judge>` judgement.
+7. Skip error abduction when `len(interaction_history) > 1`.
+8. Write `<refinement>` before abduction when refinement is required.
+9. Hand-edit `graph.json` with Python or ad-hoc JSON patches.
+10. Ignore pending history and refine only one latest query when unrefined queries already exist.
+11. Invent a shorter pipeline ("read file → write refinement → apply").
+12. Apply actions without first writing evidence to the ledger.
+13. Skip post-apply verification after apply.
+
+If validation fails, **fix the trace and re-run the missing step** — do not bypass with `--skip-trace-check`.
+
+---
+
+## Constants (match `refine_runner.py` / Reafiner)
+
+```text
+MAX_HOPS = 4
+INCREMENT_HOP = 1
+BASE_TOP_K = 10
+MAX_TRIPLE_NUM_BY_STEP = [5, 10, 15, 20]   # cap triples per step
+HISTORY_HORIZON = 4                        # abduction uses last N steps
+```
+
+---
+
+## Mandatory artifacts
+
+For each query, maintain:
+
+`graphify-out/.deeprefine/loop_trace_<query_id>.json`
+
+Create template:
+
+```bash
+deeprefine loop init --query "<exact question>"
+```
+
+Append each hop to `interaction_history` **before** starting the next hop.
+Run `deeprefine loop validate --trace-file ...` after abduction and before `review` / approved `apply`.
+
+### Evidence ledger
+
+**Every phase boundary** must append to the evidence ledger:
+
+```
+graphify-out/.deeprefine/ledger.jsonl
+```
+
+Format per entry:
+
+```json
+{"ts":"<ISO8601>","query_id":"<id>","phase":"<name>","artifacts":["<path>"],"status":"started|completed|failed","qa":"<self-check result>","model":"<model used>"}
+```
+
+Write at these phase boundaries:
+- After `loop init`
+- After each hop judgement (step N judge)
+- After abduction
+- After refinement actions generated
+- After `loop validate`
+- After review (including 5-oracle results)
+- After user approval received
+- After `apply` + post-apply verification
+- After `loop finish`
+
+---
+
+## Query queue selection (default behavior of `/deeprefine`)
+
+`/deeprefine` must process **all unrefined history queries** first, not just the latest one.
+
+1. Sync graphify query memory into DeepRefine history:
+   - run: `deeprefine history sync-memory`
+   - source dir: `graphify-out/memory/query_*.md`
+   - target file: `graphify-out/.deeprefine/history.jsonl`
+2. Read pending queue from `graphify-out/.deeprefine/history.jsonl`:
+   - include rows where `refined != true`
+   - dedupe by `id` (first occurrence)
+   - preserve file order
+3. If pending queue is non-empty: set `target_queries = pending_queue`.
+4. If pending queue is empty: set `target_queries = [current session question]`.
+
+**CRITICAL — OpenCode optimization #1: Parallel query processing (two-stage)**
+
+Instead of processing queries sequentially, use a TWO-STAGE architecture to avoid background task notification loss:
+
+**Stage 1 — Parallel processing (sub-agents do query → refine → save ONLY):** Launch each query in a parallel subagent. Sub-agents NEVER call `task()` internally.
+
+```
+Run: deeprefine history sync-memory
+target_queries = pending_history_queries() or [current session question]
+
+For EACH question in target_queries, launch a parallel subagent:
+  task(description="Process query: {question}",
+       prompt="Process this query: judge→abduction→refinement→save to file.
+               Query: '{question}'. Write todowrite. Write ledger.
+               Save refinement to graphify-out/.deeprefine/refinement_actions_<id>.txt
+               Do NOT launch any subagents. Do NOT review. Just save and return.")
+```
+
+Each subagent independently runs the core Reafiner loop (query → judge → k-hop → abduction → refinement → save file). For early-exit queries, finish immediately. For refinement-path queries, save the actions file and return.
+
+**Stage 2 — Centralized Oracle review (main agent collects files, launches reviews):** After ALL Stage 1 subagents complete, the main agent collects all generated refinement_actions_*.txt files. For EACH file, launch 5 oracle reviews (see "5-Oracle parallel review" section). Oracles read the file and return APPROVE/REJECT.
+
+**Stage 3 — Auto-approve gate (main agent decides):** Main agent checks all oracle verdicts + review labels. Actions that are ALL HIGH confidence + 5/5 APPROVE → auto-apply. Others → flag for human review.
+
+Do NOT make sub-agents call task() — always launch oracles from the main agent.
+
+---
+
+## Control flow (must match `Reafiner.refine()`)
+
+Pseudocode — follow **exactly**:
+
+```text
+target_queries = pending_history_queries()  # refined != true, dedupe by id, keep order
+run "deeprefine history sync-memory" before loading pending history
+if target_queries is empty:
+    target_queries = [current session question]
+
+# OpenCode optimization #1: Parallel fan-out (Stage 1)
+for question in target_queries:
+    launch parallel subagent via task() to process this question independently
+# Sub-agents NEVER call task() internally — they only save files
+
+Within each subagent, for its assigned question (Stage 1 ONLY — query → refine → save):
+    interaction_history = []
+    for step in 1..MAX_HOPS:
+        todowrite status="in_progress" for phase "Query {id} / Step {step}"
+
+        if step == 1:
+            # Vector-retrieval equivalent: graphify query on full question
+            RUN: graphify query "<question>"
+            triples = parse NODE/EDGE → [{subject, relation, object}, ...]
+            cap = MAX_TRIPLE_NUM_BY_STEP[0]  # 5
+            record retrieval.method = "graphify_query"
+        else:
+            # k-hop expansion from entities in previous hop (NOT a new random search)
+            entities = unique subjects/objects from previous triples
+            expand 1-hop neighbors from graphify-out/graph.json (or graphify query on entities)
+            cap = MAX_TRIPLE_NUM_BY_STEP[step-1]
+            record retrieval.method = "k_hop_expansion" or "graphify_query+k_hop_expansion"
+
+        triples = dedupe; len(triples) <= cap
+
+        # Answerable judgement — prefer DEEPREFINE_JUDGE_MODEL if set (cheap, fast)
+        answerable, judgement_raw = LLM_judge(question, triples)
+        MUST output ONLY: <judge>Yes</judge> or <judge>No</judge>
+
+        append interaction_history with:
+          step, query, num_hops=(step-1)*INCREMENT_HOP, base_top_k=10,
+          retrieved_subgraph, answerable, judgement_raw,
+          retrieval: {method, evidence: "<command output excerpt>"}
+
+        # Write ledger entry for this hop
+        append to graphify-out/.deeprefine/ledger.jsonl:
+          {"ts":"<now>","query_id":"<id>","phase":"step_{step}_judge","artifacts":["loop_trace_<id>.json"],"status":"completed","qa":"<judge result>","model":"<model used>"}
+
+        if answerable:
+            BREAK   # stop hop loop
+
+    # --- same branch as Reafiner.refine() line 314+ ---
+    if len(interaction_history) <= 1:
+        # Early exit: first hop was answerable — NO graph refinement
+        set trace.early_exit = true
+        deeprefine loop finish --trace-file ...   # no --refinement-file
+        todowrite status="completed" for query
+        write ledger: phase "early_exit" status "completed"
+        CONTINUE  # move to next pending query (or subagent returns)
+    else:
+        # len > 1 → ALWAYS error abduction + actions (even if last hop was Yes)
+        # OpenCode optimization #2: Use DEEPREFINE_REFINE_MODEL for abduction/refinement
+        error_abduction = LLM_abduction(interaction_history[-HISTORY_HORIZON:])
+        MUST output: <abduction>...</abduction>
+
+        actions = LLM_kg_refinement(
+            last_hop.retrieved_subgraph,
+            error_abduction,
+            question,
+            source file hints from triples,
+        )
+        MUST output: <refinement>insert_edge(...)|...</refinement>
+
+        save refinement to graphify-out/.deeprefine/refinement_actions_<id>.txt
+        deeprefine loop validate --trace-file ... --refinement-file ...
+        write ledger: phase "abduction_refinement" status "completed"
+
+        todowrite status="completed" label="Refinement saved for query {id}"
+        # Sub-agent returns here. Do NOT launch oracles. Do NOT review.
+
+# --- Stage 2: Main agent collects all refinement files and reviews ---
+Run: deeprefine review --trace-file ... --refinement-file ...
+SHOW review labels: HIGH / MEDIUM / LOW for ALL refinement_actions_*.txt files
+
+# For EACH refinement file, launch 5 Oracle reviews IN PARALLEL from MAIN agent:
+# See "5-Oracle parallel review" section for exact oracle prompts.
+# ALL must return APPROVE before proceeding.
+
+SHOW: combined 5-oracle review with per-oracle verdicts for each query
+SHOW: 5-oracle verdict summaries
+
+# --- Stage 3: Auto-approve gate (main agent decides) ---
+for each refinement file:
+    if ALL 5 oracles APPROVE AND ALL actions labeled HIGH:
+        → AUTO-APPLY: deeprefine apply --trace-file ... --refinement-file ...
+        → Post-apply verify: graphify query "<original question>"
+        → write ledger: phase "post_apply_verify" status "completed|needs_attention"
+    else:
+        → FLAG for human review
+        todowrite status="in_progress" label="Awaiting user approval for query {id}"
+        write ledger: phase "review" status "awaiting_approval"
+
+# --- Human approval for flagged items ---
+HARD STOP: do not modify graph.json in this /deeprefine turn for FLAGGED items
+Report the proposed actions, review labels, and oracle verdicts to the user
+Ask for explicit approval; approval must arrive in the user's next message
+
+# Follow-up turn only, after the user's next message explicitly approves/apply/write:
+if user explicitly approves and no LOW-confidence action remains AND all 5 oracles APPROVE:
+    deeprefine apply --trace-file ... --refinement-file ...
+    deeprefine loop finish --trace-file ... --refinement-file ...
+    # OpenCode optimization #5: Post-apply verification
+    RUN: graphify query "<original question>"
+    Verify: did the answer status change? If still not answerable, report to user.
+    write ledger: phase "post_apply_verify" status "completed|needs_attention"
+if user explicitly accepts LOW-confidence risk in that approval message:
+    deeprefine apply --allow-low-confidence --trace-file ... --refinement-file ...
+    deeprefine loop finish --trace-file ... --refinement-file ...
+    # Same post-apply verification as above
+if any oracle returned REJECT and user has not explicitly overridden:
+    Report which oracle(s) rejected and why
+    Ask user to either: (a) override and apply anyway, or (b) fix and re-run refinement
+    Do NOT apply until user decision
+```
+
+**Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+
+**Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
+
+---
+
+## 5-Oracle parallel review (OpenCode optimization #4 — Stage 2: Main Agent runs this)
+
+**This review runs AFTER all Stage 1 sub-agents have completed and saved their refinement files. The main agent collects ALL refinement_actions_*.txt files and launches this review. Sub-agents NEVER run oracle reviews.**
+
+For EACH refinement file, the main agent launches 5 reviews in parallel:
+
+```
+# 1. Collect all pending refinement files
+refinement_files = glob("graphify-out/.deeprefine/refinement_actions_*.txt")
+
+# 2. For each file, launch 5 oracle reviews in parallel from the MAIN agent (NOT from sub-agents)
+for each file in refinement_files:
+    task(subagent_type="general", description="Oracle 1: Completeness audit",
+         prompt="Review the refinement actions at {file}. Are they COMPLETE —
+         do they fully address every category (incompleteness, incorrectness, redundancy)
+         identified in the abduction? Return APPROVE or REJECT with specific reasoning.")
+
+    task(subagent_type="general", description="Oracle 2: Correctness audit",
+         prompt="Review the refinement actions at {file}. Are the edges/nodes
+         factually CORRECT based on source code? Flag any wrong facts.
+         Return APPROVE or REJECT with specific reasoning.")
+
+    task(subagent_type="general", description="Oracle 3: Safety audit",
+         prompt="Review the refinement actions at {file}. Will these changes
+         BREAK the existing graph structure? Check: orphaned nodes, broken chains,
+         conflicting relations, duplicate edges. Return APPROVE or REJECT.")
+
+    task(subagent_type="general", description="Oracle 4: Consistency audit",
+         prompt="Review the refinement actions at {file}. Do new edges create
+         CYCLES, ambiguity, or self-contradiction? Check: circular relations,
+         node label collisions. Return APPROVE or REJECT.")
+
+    task(subagent_type="general", description="Oracle 5: Edge-case audit",
+         prompt="Review the refinement actions at {file} and the original question.
+         Does the fix handle EDGE CASES, not just the happy path?
+         Consider: ambiguous entity names, multi-hop paths, partial matches.
+         Return APPROVE or REJECT.")
+```
+
+**Gate rule:** ALL 5 oracles must return APPROVE before apply proceeds. If any oracle returns REJECT, the main agent must:
+1. Report which oracle(s) rejected and their specific reasoning
+2. Ask the user: "Override and apply anyway, or abort and re-run refinement?"
+3. Do NOT apply until the user explicitly responds
+
+**Auto-approve rule (Stage 3):** Actions that are ALL HIGH confidence (from deeprefine review) AND 5/5 APPROVE → auto-apply immediately. All others → flag for human review.
+
+---
+
+## Evidence-aware review rules
+
+Before any graph write, run:
+
+```bash
+deeprefine review --trace-file graphify-out/.deeprefine/loop_trace_<id>.json --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+```
+
+The review must label every action:
+
+- `HIGH`: direct graph or code evidence exists.
+- `MEDIUM`: k-hop context supports the action, but direct code or exact-edge evidence is missing.
+- `LOW`: endpoint nodes are ambiguous, too broad, cross-community, or cannot be grounded in `graph.json`.
+
+Bare names such as `main()`, `run()`, `train()`, `test()`, and `setup()` are ambiguous even if they match only one node. Prefer file-qualified labels such as `trainer_Brain_CLS.py::train_epoch()`.
+
+`deeprefine apply` refuses LOW-confidence actions by default. Use `--allow-low-confidence` only when the user explicitly approves the risk.
+
+---
+
+## LLM prompts (verbatim — do not paraphrase)
+
+### Judgement (`_answerable_judgement`)
+
+**System:**
+
+```text
+As an advanced judgement assistant, your task is to judge whether the given question is answerable based on the provided KG context.
+
+Evaluate whether the given question is answerable based on the provided KG context. Output your judgment in the following format:
+<judge>Yes</judge> or <judge>No</judge>
+
+**Important:** You must think carefully about the question and the KG context before making your judgment. And output your judgment result directly in the specified format.
+```
+
+**User:**
+
+```text
+Question: {question}
+Knowledge Graph (KG) context: {triples_string}
+```
+
+`{triples_string}` = one triple per line: `subject | relation | object`
+
+### Error abduction (`_error_abduction`) — only if `len(interaction_history) > 1`
+
+**System:**
+
+```text
+As an advanced error abduction assistant, your task is to analyze the error reasons based on the given interaction history.
+
+Analyze the reasons of the unanswerable questions based on the given interaction history from the incompleteness, incorrectness, and redundancy perspectives. Output your analysis in the following format:
+<abduction>...</abduction>
+
+**Important:** You must think carefully about the interaction history before making your analysis. And output your analysis result directly in the specified format.
+```
+
+**User:**
+
+```text
+Interaction history: {interaction_history}
+```
+
+`{interaction_history}` format (same as Reafiner):
+
+```text
+Step1:
+['Query': ..., 'Subgraph_hop': ..., 'Subgraph_content': ..., 'Answerable': ...]
+
+Step2:
+...
+```
+
+### KG refinement actions (`_kg_refinement_action`) — only if `len(interaction_history) > 1`
+
+**System:**
+
+```text
+As an advanced knowledge graph refinement assistant, your task is to generate a series of actions (**within 10 actions**) to refine the given KG to make it more suitable for answering the given question.
+
+Based on the given KG and the analysed error reasons, refine the given KG to make it more easily for retrieval and answering the given question. You have the following three types of actions to conduct:
+
+- insert_edge(subject, relation, object): Insert a new edge into the KG to complete the missing information.
+- delete_edge(subject, relation, object): Delete an edge from the KG to remove the redundant information or conflicting information.
+- replace_node(old_entity, new_entity): Replace an entity in the KG to correct the errors or deal with disambiguation.
+
+Output a series of actions (**within 10 actions**) in the following format:
+<refinement>insert_edge("...", "...", "...")|delete_edge("...", "...", "...")|replace_node("...", "...")|...</refinement>
+
+**Important:** You must think carefully about the given KG and the analysed error reasons before making your refinement. DO NOT DELETE ANY IRRELEVANT TRIPLES FROM THE ORIGINAL KG. TRY TO KEEP THE ORIGINAL KG AS MUCH AS POSSIBLE. DO NOT GENERATE TOO MANY ACTIONS. And output your refinement result directly in the specified format.
+```
+
+**User:**
+
+```text
+Original Text: {original_text}
+KG: {triples_string}
+Question: {question}
+Error reasons: {error_reasons}
+```
+
+Use **last hop's** `retrieved_subgraph` as `{triples_string}` (JSON list is OK in trace; string form for the prompt).
+
+### KG Refinement — OpenCode schema constraints
+
+To prevent invalid refinement actions, the Agent MUST enforce these constraints before generating `<refinement>` output.
+
+<existing_edge_types>
+Valid relation types in this graph (from graph.json). Use ONLY these types:
+- calls, contains, imports_from, references, defined_in, has_method, rationale_for
+- part_of, defines, imports, returns, instantiates, validates_field, exports
+
+Do NOT invent new relation types (e.g. assign_confidence, references_constant, has_parameter).
+If the concept cannot be expressed with an existing edge type, do NOT generate the action.
+</existing_edge_types>
+
+<format_constraint>
+Every insert_edge(subject, relation, object) must use node labels from graph.json
+as subject and object. Node labels look like:
+  - File paths:  "agent_loop.py", "action_review.py"
+  - Functions:   "validate_trace()", "review_action()"
+  - Concepts:    "DeepRefine Agent Loop Workflow"
+
+Do NOT use natural language sentences as node labels.
+Do NOT use 4-argument insert_edge (only 3 arguments: subject, relation, object).
+
+WRONG: insert_edge("review_action()", "assigns_confidence", "LOW", "when warnings...")
+RIGHT: insert_edge("review_action()", "calls", "_matching_nodes()")
+</format_constraint>
+
+<operation_constraint>
+Only these 3 operations are supported by the apply engine (agent_graph.py):
+  - insert_edge(subject, relation, object)
+  - delete_edge(subject, relation, object)
+  - replace_node(old_entity, new_entity)
+
+Do NOT use insert_node, update_node, merge_node, or any other operation type.
+The apply engine will REJECT any unrecognized operation.
+</operation_constraint>
+
+---
+
+## Per-query checklist (use todowrite — OpenCode optimization #3)
+
+Do NOT use a text checklist. Instead, use `todowrite()` at each phase boundary:
+
+```
+todowrite(todos=[
+  {"content": "Phase: sync-memory — sync graphify query memory to history.jsonl", "status": "completed", "priority": "high"},
+  {"content": "Phase: init — create loop_trace_<id>.json for query {id}", "status": "completed", "priority": "high"},
+  {"content": "Phase: step_1 — graphify query + judge hop 0 for query {id}", "status": "in_progress", "priority": "high"},
+  {"content": "Phase: step_{N} — k-hop expansion + judge hop {N-1} for query {id}", "status": "pending", "priority": "high"},
+  {"content": "Phase: abduction — analyze error reasons for query {id}", "status": "pending", "priority": "high"},
+  {"content": "Phase: refinement — generate actions for query {id}", "status": "pending", "priority": "high"},
+  {"content": "Phase: validate — CLI loop validate for query {id}", "status": "pending", "priority": "high"},
+  {"content": "Phase: review — evidence review + 5-oracle audit for query {id}", "status": "pending", "priority": "high"},
+  {"content": "Phase: await_approval — HARD STOP, waiting for user approval for query {id}", "status": "pending", "priority": "high"},
+  {"content": "Phase: apply — apply approved actions + post-apply verify for query {id}", "status": "pending", "priority": "high"},
+  {"content": "Phase: finish — loop finish + ledger write for query {id}", "status": "pending", "priority": "high"},
+])
+```
+
+This replaces the Cursor text checklist. OpenCode agents can see real-time progress and resume from the last completed phase.
+
+---
+
+## Mode selection
+
+Three slash commands for different workflow entry points:
+
+| Command | Scope | When to use |
+|---------|-------|-------------|
+| `/deeprefine` | Full pipeline: sync → judge → abduction → refinement → review → (await approval) → apply → verify | Normal usage: process all pending queries |
+| `/deeprefine-review` | Review only: read actions file → 5-oracle audit → evidence review → present results | Actions already generated, need quality audit |
+| `/deeprefine-apply` | Apply only: read actions → confirm → apply → post-apply verify → finish | Review complete, user approved in previous turn |
+
+**Auto-detection logic in `/deeprefine`:**
+- If `refinement_actions_<id>.txt` exists and `loop_trace_<id>.json` shows validation passed but review not done → offer to run `/deeprefine-review`
+- If review report exists and all actions reviewed → offer to run `/deeprefine-apply`
+- If neither exists → start full pipeline
+
+---
+
+## Commands (in order)
+
+```bash
+# 0. KB project root; graphify-out/graph.json exists
+mkdir -p graphify-out/.deeprefine
+cp graphify-out/graph.json graphify-out/.deeprefine/graph.json.bak
+
+# 1. Sync graphify query memory to deeprefine history first.
+deeprefine history sync-memory
+
+# 2. Build target query list:
+#    - preferred: all pending from history.jsonl (refined != true)
+#    - fallback: current session question (single query)
+deeprefine history list --pending
+
+# 3. OpenCode optimization: Launch parallel subagents for EACH query
+#    Each subagent runs the full pipeline independently.
+
+# 4–7. Per subagent: graphify/graph read → judge → append to loop_trace_*.json
+#    Use todowrite for progress, write ledger after each phase.
+
+# 8a. Early exit (len(history)==1 and answerable)
+deeprefine loop validate --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
+deeprefine loop finish --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
+
+# 8b. Refinement path (len(history)>1): validate → 5-oracle review → deeprefine review
+deeprefine loop validate --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+# Launch 5 oracle subagents in parallel (see "5-Oracle parallel review" section)
+deeprefine review --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+
+# HARD STOP.
+# A normal /deeprefine run must end here.
+# Report the review, oracle verdicts, and ledger to the user.
+# Ask for explicit approval.
+# Do NOT run deeprefine apply in the same /deeprefine turn.
+
+# Approval-only follow-up commands, only after the user explicitly says approve/apply:
+deeprefine apply --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+# Optional explicit risk override:
+# deeprefine apply --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+deeprefine loop finish --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+
+# Post-apply verification (OpenCode optimization #5):
+graphify query "<original question>"
+# Verify answerability changed. If still not answerable, report to user with full ledger context.
+```
+
+---
+
+## `loop_trace_*.json` schema
+
+```json
+{
+  "schema_version": 1,
+  "mode": "agent-loop",
+  "query": "what is dulce?",
+  "query_id": "5cdc0798eb59b486",
+  "constants": { "max_hops": 4, "increment_hop": 1, "base_top_k": 10,
+    "max_triple_num_by_step": [5, 10, 15, 20], "history_horizon_size": 4 },
+  "interaction_history": [
+    {
+      "step": 1,
+      "num_hops": 0,
+      "base_top_k": 10,
+      "query": "what is dulce?",
+      "retrieval": {
+        "method": "graphify_query",
+        "evidence": "graphify query \"what is dulce?\" → …"
+      },
+      "retrieved_subgraph": [
+        {"subject": "A", "relation": "r", "object": "B"}
+      ],
+      "answerable": false,
+      "judgement_raw": "<judge>No</judge>"
+    }
+  ],
+  "error_abduction_reason": "…",
+  "error_abduction_raw": "<abduction>…</abduction>",
+  "refinement_action_file": "graphify-out/.deeprefine/refinement_actions_<id>.txt",
+  "early_exit": false,
+  "oracle_review": {
+    "completeness": "APPROVE",
+    "correctness": "APPROVE",
+    "safety": "APPROVE",
+    "consistency": "APPROVE",
+    "edge_cases": "APPROVE"
+  },
+  "ledger_ref": "graphify-out/.deeprefine/ledger.jsonl"
+}
+```
+
+Note: `oracle_review` and `ledger_ref` are OpenCode-specific trace extensions.
+
+---
+
+## Evidence ledger schema
+
+```
+graphify-out/.deeprefine/ledger.jsonl
+```
+
+One JSON object per line, appended at every phase boundary:
+
+```json
+{"ts":"2026-07-02T20:40:00Z","query_id":"5cdc0798eb59b486","phase":"step_1_judge","artifacts":["loop_trace_5cdc0798eb59b486.json"],"status":"completed","qa":"judge returned No","model":"gpt-4o-mini"}
+{"ts":"2026-07-02T20:40:15Z","query_id":"5cdc0798eb59b486","phase":"step_2_judge","artifacts":["loop_trace_5cdc0798eb59b486.json"],"status":"completed","qa":"judge returned No","model":"gpt-4o-mini"}
+{"ts":"2026-07-02T20:41:00Z","query_id":"5cdc0798eb59b486","phase":"abduction_refinement","artifacts":["loop_trace_5cdc0798eb59b486.json","refinement_actions_5cdc0798eb59b486.txt"],"status":"completed","qa":"generated 3 actions","model":"claude-sonnet-4-20250514"}
+{"ts":"2026-07-02T20:42:00Z","query_id":"5cdc0798eb59b486","phase":"review","artifacts":["loop_trace_5cdc0798eb59b486.json","refinement_actions_5cdc0798eb59b486.txt"],"status":"awaiting_approval","qa":"5/5 oracles APPROVE, review: 2 HIGH, 1 MEDIUM, 0 LOW","model":"claude-sonnet-4-20250514"}
+```
+
+---
+
+## Optional: CLI mode (FAISS + API)
+
+Only when the user **explicitly** requests `deeprefine refine` / full runtime:
+
+```bash
+conda activate atlastune
+export DEEPREFINE_EMBED_URL=... DEEPREFINE_LLM_URL=...
+deeprefine refine --query "..."       # dry-run proposal only
+# deeprefine refine --query "..." --apply   # only when the user explicitly wants CLI mode to write graph.json
+```
+
+---
+
+## Paths
+
+- `graphify-out/graph.json`
+- `graphify-out/.deeprefine/loop_trace_*.json` (**required**)
+- `graphify-out/.deeprefine/refinement_actions_*.txt`
+- `graphify-out/.deeprefine/refinement_results_*.jsonl`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.md`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.json`
+- `graphify-out/.deeprefine/graph.json.bak`
+- `graphify-out/.deeprefine/ledger.jsonl` (**new — OpenCode evidence ledger**)

--- a/deeprefine_skill/cli.py
+++ b/deeprefine_skill/cli.py
@@ -1,9 +1,10 @@
 """DeepRefine CLI — command-line entry point for the DeepRefine agent skill.
 
 Provides subcommands for platform-specific skill installation (Cursor,
-Copilot CLI, Gemini CLI), query-history management, FAISS index
-rebuilding, dry-run refinement review, graph refinement, loop-trace
-lifecycle management, and applying refinement actions to ``graph.json``.
+Copilot CLI, Gemini CLI, Codex, OpenCode), query-history management,
+FAISS index rebuilding, dry-run refinement review, graph refinement,
+loop-trace lifecycle management, and applying refinement actions to
+``graph.json``.
 """
 
 from __future__ import annotations
@@ -27,11 +28,13 @@ from deeprefine_skill.installers import (
     install_copilot_skill,
     install_cursor_skill,
     install_gemini_extension,
+    install_opencode_skill,
     link_gemini_extension,
     uninstall_codex_skill,
     uninstall_copilot_skill,
     uninstall_cursor_skill,
     uninstall_gemini_extension,
+    uninstall_opencode_skill,
 )
 from deeprefine_skill.paths import (
     env_defaults,
@@ -124,6 +127,38 @@ def cmd_codex_uninstall(args: argparse.Namespace) -> int:
     if removed:
         scope = "project" if args.project else "user"
         print(f"Removed DeepRefine Codex skill ({scope}).")
+    else:
+        print("Skill not installed at the selected scope.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# OpenCode handlers
+# ---------------------------------------------------------------------------
+
+
+def cmd_opencode_install(args: argparse.Namespace) -> int:
+    """``deeprefine opencode install`` - install skill + commands for OpenCode."""
+    dest = install_opencode_skill(project=args.project)
+    scope = "project" if args.project else "user"
+    print(f"Installed DeepRefine OpenCode skill ({scope}) -> {dest}")
+    cwd_root = Path.cwd() if args.project else Path.home()
+    cmd_dir = cwd_root / ".opencode" / "commands"
+    cmds = list(cmd_dir.glob("deeprefine*.md"))
+    print(f"Installed {len(cmds)} command(s) → {cmd_dir}")
+    for cmd in sorted(cmds):
+        print(f"  /{cmd.stem}")
+    if args.project:
+        print("Restart or reload OpenCode, then invoke /deeprefine.")
+    return 0
+
+
+def cmd_opencode_uninstall(args: argparse.Namespace) -> int:
+    """``deeprefine opencode uninstall`` - remove the OpenCode skill + commands."""
+    removed = uninstall_opencode_skill(project=args.project)
+    if removed:
+        scope = "project" if args.project else "user"
+        print(f"Removed DeepRefine OpenCode skill and commands ({scope}).")
     else:
         print("Skill not installed at the selected scope.")
     return 0
@@ -641,6 +676,36 @@ def main(argv: list[str] | None = None) -> int:
         user_help="Remove from ~/.codex/skills/deeprefine (all projects)",
     )
     p_codu.set_defaults(func=cmd_codex_uninstall, _default_project=True)
+
+    # deeprefine opencode install | uninstall
+    p_opencode = sub.add_parser("opencode", help="OpenCode IDE integration")
+    opencode_sub = p_opencode.add_subparsers(dest="opencode_cmd", required=True)
+
+    p_opi = opencode_sub.add_parser(
+        "install", help="Install /deeprefine skill for OpenCode"
+    )
+    _add_project_flag(
+        p_opi,
+        project_help=(
+            "Install to .opencode/skills/deeprefine in the current directory "
+            "(default for opencode install)"
+        ),
+        user_help="Install to ~/.opencode/skills/deeprefine (all projects)",
+    )
+    p_opi.set_defaults(func=cmd_opencode_install, _default_project=True)
+
+    p_opu = opencode_sub.add_parser(
+        "uninstall", help="Remove OpenCode skill and commands"
+    )
+    _add_project_flag(
+        p_opu,
+        project_help=(
+            "Remove from .opencode/skills/deeprefine and .opencode/commands "
+            "in the current directory (default for opencode uninstall)"
+        ),
+        user_help="Remove from ~/.opencode/skills/deeprefine (all projects)",
+    )
+    p_opu.set_defaults(func=cmd_opencode_uninstall, _default_project=True)
 
     # deeprefine gemini link | install | uninstall | path
     p_gemini = sub.add_parser("gemini", help="Gemini CLI integration")

--- a/deeprefine_skill/commands/opencode/deeprefine-apply.md
+++ b/deeprefine_skill/commands/opencode/deeprefine-apply.md
@@ -1,0 +1,25 @@
+---
+description: Apply approved DeepRefine refinement actions to the knowledge graph with explicit user confirmation and post-apply auto-verification
+---
+
+# /deeprefine-apply
+
+<command-instruction>
+Use the `skill` tool to load the DeepRefine skill:
+
+skill(name="deeprefine")
+
+Execute the APPLY phase only:
+1. Read the latest refinement actions file from `graphify-out/.deeprefine/`
+2. Read the review report to confirm all actions have been reviewed
+3. Show exactly what will be applied to `graph.json`
+4. **Ask for explicit user confirmation** — do NOT apply without approval
+5. Apply approved actions: `deeprefine apply --trace-file ... --refinement-file ...`
+6. Run `deeprefine loop finish --trace-file ... --refinement-file ...`
+7. **Post-apply verification**: re-query graphify for the original question to confirm the graph mutation was effective
+8. Write evidence to the ledger
+
+Do NOT run the judge→abduction→refinement pipeline. Do NOT review — use `/deeprefine-review` for that. This command only applies already-reviewed and explicitly-approved actions.
+
+<user-request>$ARGUMENTS</user-request>
+</command-instruction>

--- a/deeprefine_skill/commands/opencode/deeprefine-review.md
+++ b/deeprefine_skill/commands/opencode/deeprefine-review.md
@@ -1,0 +1,22 @@
+---
+description: Review existing DeepRefine refinement actions — evidence-aware scoring (HIGH/MEDIUM/LOW) of proposed knowledge graph changes with 5-oracle parallel audit
+---
+
+# /deeprefine-review
+
+<command-instruction>
+Use the `skill` tool to load the DeepRefine skill:
+
+skill(name="deeprefine")
+
+Execute the REVIEW phase only:
+1. Read the latest refinement actions file from `graphify-out/.deeprefine/`
+2. Launch 5 parallel oracle subagents reviewing from orthogonal angles (completeness, correctness, safety, graph consistency, edge-case coverage)
+3. Score each action (HIGH/MEDIUM/LOW) using evidence-aware review
+4. Present results with clear recommendations
+5. Write evidence to the ledger
+
+Do NOT apply any changes. Do NOT re-run the judge→abduction→refinement pipeline. This command only reviews existing actions.
+
+<user-request>$ARGUMENTS</user-request>
+</command-instruction>

--- a/deeprefine_skill/commands/opencode/deeprefine.md
+++ b/deeprefine_skill/commands/opencode/deeprefine.md
@@ -1,0 +1,15 @@
+---
+description: Full DeepRefine workflow — process pending queries through judge→abduction→refinement→review→apply pipeline with 6 OpenCode-native optimizations
+---
+
+# /deeprefine
+
+<command-instruction>
+Use the `skill` tool to load the DeepRefine skill:
+
+skill(name="deeprefine")
+
+Then execute the full workflow described in the skill. Process all pending queries from `graphify-out/history.jsonl` through the complete judge→abduction→refinement→review→apply pipeline. Leverage all 6 OpenCode-native optimizations: parallel query processing, phase-specific model routing, structured progress tracking, 5-oracle parallel review, post-apply verification, and evidence ledger.
+
+<user-request>$ARGUMENTS</user-request>
+</command-instruction>

--- a/deeprefine_skill/installers.py
+++ b/deeprefine_skill/installers.py
@@ -1,10 +1,10 @@
-"""Installers for agent-platform skill files (Cursor, Copilot CLI, Gemini CLI).
+"""Installers for agent-platform skill files (Cursor, Copilot CLI, Gemini CLI, OpenCode).
 
 Each platform has a source SKILL.md variant (SKILL.md for Cursor,
-SKILL_COPILOT.md for Copilot CLI, gemini_extension/ for Gemini CLI)
-bundled in the wheel or found at the repo root during editable installs.
-The install/remove functions copy the appropriate variant into the
-platform-specific directory.
+SKILL_COPILOT.md for Copilot CLI, gemini_extension/ for Gemini CLI,
+SKILL_OPENCODE.md for OpenCode) bundled in the wheel or found at the
+repo root during editable installs. The install/remove functions copy
+the appropriate variant into the platform-specific directory.
 """
 
 from __future__ import annotations
@@ -15,12 +15,14 @@ from pathlib import Path
 
 _SKILL_MD_NAME = "SKILL.md"
 _SKILL_COPILOT_MD_NAME = "SKILL_COPILOT.md"
+_SKILL_OPENCODE_MD_NAME = "SKILL_OPENCODE.md"
 _CODEX_SKILL_DIR = "codex_skill"
 _CODEX_AGENTS_DIR = "agents"
 _CODEX_REFERENCES_DIR = "references"
 _LEGACY_CODEX_AGENT_LOOP_REF_NAME = "deeprefine-agent-loop.md"
 _OPENAI_YAML_NAME = "openai.yaml"
 _GEMINI_EXTENSION_NAME = "deeprefine-skill"
+_OPENCODE_COMMANDS_DIR = "commands"
 
 # ---------------------------------------------------------------------------
 # Source-file resolution
@@ -419,3 +421,103 @@ def uninstall_gemini_extension(
         return True
     # Also clean up the old manual-copy fallback if present.
     return remove_copied_gemini_extension(target_dir)
+
+
+# ---------------------------------------------------------------------------
+# OpenCode
+# ---------------------------------------------------------------------------
+
+
+def _opencode_skill_source() -> Path:
+    """Return the path to the OpenCode SKILL_OPENCODE.md source."""
+    return _resolve_skill_source(_SKILL_OPENCODE_MD_NAME)
+
+
+def _opencode_commands_source_dir() -> Path:
+    """Return the directory containing OpenCode command .md files."""
+    bundled = Path(__file__).resolve().parent / _OPENCODE_COMMANDS_DIR / "opencode"
+    if bundled.is_dir() and list(bundled.glob("*.md")):
+        return bundled
+    repo_root = Path(__file__).resolve().parents[1]
+    fallback = repo_root / "deeprefine_skill" / _OPENCODE_COMMANDS_DIR / "opencode"
+    if fallback.is_dir() and list(fallback.glob("*.md")):
+        return fallback
+    raise FileNotFoundError(
+        "Missing OpenCode command templates (expected under "
+        "deeprefine_skill/commands/opencode/)."
+    )
+
+
+def install_opencode_skill(*, project: bool) -> Path:
+    """Install the OpenCode skill and commands.
+
+    Copies:
+    - ``SKILL_OPENCODE.md`` → ``.opencode/skills/deeprefine/SKILL.md``
+    - ``commands/opencode/*.md`` → ``.opencode/commands/*.md``
+
+    Parameters
+    ----------
+    project : bool
+        If *True*, install under the current working directory
+        (``.opencode/skills/deeprefine/``).  If *False*, install under
+        ``~/.opencode/skills/deeprefine/`` (user-wide).
+
+    Returns
+    -------
+    Path
+        Destination path of the installed ``SKILL.md``.
+    """
+    src_skill = _opencode_skill_source()
+    src_commands = _opencode_commands_source_dir()
+    if project:
+        dest_skill_dir = Path.cwd() / ".opencode" / "skills" / "deeprefine"
+        dest_cmd_dir = Path.cwd() / ".opencode" / "commands"
+    else:
+        dest_skill_dir = Path.home() / ".claude" / "skills" / "deeprefine"
+        dest_cmd_dir = Path.home() / ".opencode" / "commands"
+    dest_skill_dir.mkdir(parents=True, exist_ok=True)
+    dest_cmd_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src_skill, dest_skill_dir / _SKILL_MD_NAME)
+    for cmd in src_commands.glob("*.md"):
+        shutil.copy2(cmd, dest_cmd_dir / cmd.name)
+    return dest_skill_dir / _SKILL_MD_NAME
+
+
+def uninstall_opencode_skill(*, project: bool) -> bool:
+    """Remove a previously installed OpenCode skill and commands.
+
+    Returns
+    -------
+    bool
+        *True* if any file was removed, *False* if nothing was installed.
+    """
+    if project:
+        dest_skill = Path.cwd() / ".opencode" / "skills" / "deeprefine" / _SKILL_MD_NAME
+        dest_cmd_dir = Path.cwd() / ".opencode" / "commands"
+    else:
+        dest_skill = Path.home() / ".opencode" / "skills" / "deeprefine" / _SKILL_MD_NAME
+        dest_cmd_dir = Path.home() / ".opencode" / "commands"
+    removed = False
+    if dest_skill.is_file():
+        dest_skill.unlink()
+        removed = True
+    for cmd in dest_cmd_dir.glob("deeprefine*.md"):
+        cmd.unlink()
+        removed = True
+    # Clean skill-tree parents: deeprefine/, skills/, .opencode/
+    for parent in [dest_skill.parent, dest_skill.parent.parent, dest_skill.parent.parent.parent]:
+        try:
+            parent.rmdir()
+        except OSError:
+            pass
+    # Clean commands/ if empty (only rmdir — never remove if other files exist)
+    try:
+        dest_cmd_dir.rmdir()
+    except OSError:
+        pass
+    # Clean .opencode/ itself (may still fail if commands/ was non-empty)
+    try:
+        dest_skill.parent.parent.parent.rmdir()
+    except OSError:
+        pass
+    return removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "deeprefine-cli"
 version = "0.1.9"
-description = "CLI and agent skills (Cursor, Copilot CLI, Gemini CLI, Codex) to refine graphify knowledge graphs with DeepRefine"
+description = "CLI and agent skills (Cursor, Copilot CLI, Gemini CLI, Codex, OpenCode) to refine graphify knowledge graphs with DeepRefine"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 authors = [
     {name = "HKUST-KnowComp"},
 ]
-keywords = ["deeprefine", "graphify", "knowledge-graph", "rag", "cursor", "copilot", "copilot-cli", "gemini-cli", "gemini", "codex", "agent-skill"]
+keywords = ["deeprefine", "graphify", "knowledge-graph", "rag", "cursor", "copilot", "copilot-cli", "gemini-cli", "gemini", "codex", "opencode", "agent-skill"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
@@ -45,9 +45,11 @@ include = ["deeprefine_skill*"]
 deeprefine_skill = [
     "SKILL.md",
     "SKILL_COPILOT.md",
+    "SKILL_OPENCODE.md",
     "codex_skill/SKILL.md",
     "codex_skill/agents/openai.yaml",
     "codex_skill/references/*.md",
+    "commands/opencode/*.md",
     "gemini_extension/gemini-extension.json",
     "gemini_extension/GEMINI.md",
     "gemini_extension/commands/*.toml",

--- a/tests/test_opencode_integration.py
+++ b/tests/test_opencode_integration.py
@@ -1,0 +1,233 @@
+"""Integration tests for OpenCode skill — CLI layer + frontmatter validation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_OPENCODE = REPO_ROOT / "deeprefine_skill" / "SKILL_OPENCODE.md"
+COMMANDS_DIR = REPO_ROOT / "deeprefine_skill" / "commands" / "opencode"
+EXPECTED_COMMANDS: tuple[str, ...] = (
+    "deeprefine.md",
+    "deeprefine-review.md",
+    "deeprefine-apply.md",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(text: str) -> dict[str, Any]:
+    """Parse YAML frontmatter from a markdown file (between ``---`` fences)."""
+    parts = text.split("---")
+    if len(parts) < 3:
+        return {}
+    return yaml.safe_load(parts[1]) or {}
+
+
+def _run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run ``python -m deeprefine_skill.cli`` with given args."""
+    cmd = [sys.executable, "-m", "deeprefine_skill.cli", *args]
+    return subprocess.run(
+        cmd,
+        text=True,
+        cwd=str(cwd or REPO_ROOT),
+        capture_output=True,
+    )
+
+
+def _tmp_opencode_dir(tmp_path: Path) -> Path:
+    """Create a fake .opencode layout and return that directory."""
+    return tmp_path / ".opencode"
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter tests (no filesystem side-effects)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillFrontmatter:
+    """Verify SKILL_OPENCODE.md frontmatter satisfies OpenCode skill spec."""
+
+    def test_name_field_present(self) -> None:
+        """Required field: ``name`` (1-64 chars, lowercase alphanumeric + hyphens)."""
+        text = SKILL_OPENCODE.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert "name" in fm, "missing required 'name' field"
+        name: str = fm["name"]
+        assert 1 <= len(name) <= 64, f"name length {len(name)} out of range [1,64]"
+        assert name == "deeprefine"
+
+    def test_description_field_present(self) -> None:
+        """Required field: ``description`` (1-1024 chars)."""
+        text = SKILL_OPENCODE.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert "description" in fm, "missing required 'description' field"
+        desc = fm["description"]
+        if isinstance(desc, str):
+            assert 1 <= len(desc) <= 1024, f"description length {len(desc)} out of range [1,1024]"
+
+    def test_disable_model_invocation_absent(self) -> None:
+        """Cursor-specific field must NOT leak into OpenCode skill."""
+        text = SKILL_OPENCODE.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert "disable-model-invocation" not in fm, (
+            "disable-model-invocation is Cursor-only and must not appear in OpenCode SKILL.md"
+        )
+
+    def test_license_field(self) -> None:
+        """Optional field: ``license`` should be MIT."""
+        text = SKILL_OPENCODE.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert fm.get("license") == "MIT"
+
+    def test_compatibility_field(self) -> None:
+        """Metadata field: ``compatibility`` should reference opencode."""
+        text = SKILL_OPENCODE.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert "compatibility" in fm
+        assert "opencode" in str(fm["compatibility"]).lower()
+
+
+class TestCommandFrontmatter:
+    """Verify each command .md has valid YAML frontmatter."""
+
+    @pytest.mark.parametrize("cmd_name", EXPECTED_COMMANDS)
+    def test_command_has_description(self, cmd_name: str) -> None:
+        """Every command must have a ``description`` in its frontmatter."""
+        cmd_path = COMMANDS_DIR / cmd_name
+        assert cmd_path.is_file(), f"command file missing: {cmd_path}"
+        fm = _parse_frontmatter(cmd_path.read_text(encoding="utf-8"))
+        assert "description" in fm, f"{cmd_name}: missing 'description' field"
+        assert len(str(fm["description"])) > 0
+
+    @pytest.mark.parametrize("cmd_name", EXPECTED_COMMANDS)
+    def test_command_loads_skill(self, cmd_name: str) -> None:
+        """Every command should reference ``skill(name=\"deeprefine\")``."""
+        cmd_path = COMMANDS_DIR / cmd_name
+        body = cmd_path.read_text(encoding="utf-8")
+        assert 'skill(name="deeprefine")' in body, (
+            f"{cmd_name}: missing skill(name=\"deeprefine\") invocation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Installer tests (temporary directories, no side-effects)
+# ---------------------------------------------------------------------------
+
+
+class TestOpencodeInstall:
+    """End-to-end install/uninstall in isolated temp dirs."""
+
+    def _run_install(self, cwd: Path, *, project: bool = True) -> subprocess.CompletedProcess[str]:
+        args = ["opencode", "install"]
+        if project:
+            args.append("--project")
+        return _run_cli(*args, cwd=cwd)
+
+    def _run_uninstall(self, cwd: Path, *, project: bool = True) -> subprocess.CompletedProcess[str]:
+        args = ["opencode", "uninstall"]
+        if project:
+            args.append("--project")
+        return _run_cli(*args, cwd=cwd)
+
+    def test_install_creates_skill_file(self, tmp_path: Path) -> None:
+        """Install creates .opencode/skills/deeprefine/SKILL.md."""
+        skill_dest = tmp_path / ".opencode" / "skills" / "deeprefine" / "SKILL.md"
+        result = self._run_install(cwd=tmp_path)
+        assert result.returncode == 0, f"install failed: {result.stderr}"
+        assert skill_dest.is_file(), f"SKILL.md not created at {skill_dest}"
+
+    def test_install_creates_command_files(self, tmp_path: Path) -> None:
+        """Install creates all 3 command files under .opencode/commands/."""
+        result = self._run_install(cwd=tmp_path)
+        assert result.returncode == 0, f"install failed: {result.stderr}"
+        for cmd_name in EXPECTED_COMMANDS:
+            cmd_path = tmp_path / ".opencode" / "commands" / cmd_name
+            assert cmd_path.is_file(), f"command {cmd_name} not created at {cmd_path}"
+
+    def test_uninstall_removes_skill_file(self, tmp_path: Path) -> None:
+        """Uninstall removes .opencode/skills/deeprefine/SKILL.md."""
+        self._run_install(cwd=tmp_path)
+        skill_dest = tmp_path / ".opencode" / "skills" / "deeprefine" / "SKILL.md"
+        assert skill_dest.is_file(), "precondition: install must succeed"
+
+        result = self._run_uninstall(cwd=tmp_path)
+        assert result.returncode == 0, f"uninstall failed: {result.stderr}"
+        assert not skill_dest.exists(), f"SKILL.md not removed: {skill_dest}"
+
+    def test_uninstall_removes_command_files(self, tmp_path: Path) -> None:
+        """Uninstall removes all deeprefine*.md command files."""
+        self._run_install(cwd=tmp_path)
+        for cmd_name in EXPECTED_COMMANDS:
+            assert (tmp_path / ".opencode" / "commands" / cmd_name).is_file()
+
+        result = self._run_uninstall(cwd=tmp_path)
+        assert result.returncode == 0
+        for cmd_name in EXPECTED_COMMANDS:
+            cmd_path = tmp_path / ".opencode" / "commands" / cmd_name
+            assert not cmd_path.exists(), f"command {cmd_name} not removed"
+
+    def test_uninstall_clean_dirs(self, tmp_path: Path) -> None:
+        """Uninstall cleans up empty parent directories."""
+        self._run_install(cwd=tmp_path)
+        self._run_uninstall(cwd=tmp_path)
+
+        # Commands dir may remain if other commands exist, but skill deep-dirs should be gone
+        skill_deep_dir = tmp_path / ".opencode" / "skills" / "deeprefine"
+        assert not skill_deep_dir.exists(), f"skill dir not cleaned: {skill_deep_dir}"
+
+    def test_install_idempotent(self, tmp_path: Path) -> None:
+        """Install twice should succeed (overwrite)."""
+        r1 = self._run_install(cwd=tmp_path)
+        r2 = self._run_install(cwd=tmp_path)
+        assert r1.returncode == 0
+        assert r2.returncode == 0, f"second install failed: {r2.stderr}"
+        skill_dest = tmp_path / ".opencode" / "skills" / "deeprefine" / "SKILL.md"
+        assert skill_dest.is_file()
+
+
+# ---------------------------------------------------------------------------
+# CLI help tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliHelp:
+    """Verify CLI --help output for opencode subcommands."""
+
+    def test_opencode_help_shows_subcommands(self) -> None:
+        """``deeprefine opencode --help`` shows install and uninstall."""
+        result = _run_cli("opencode", "--help")
+        assert result.returncode == 0
+        out = result.stdout
+        assert "install" in out
+        assert "uninstall" in out
+
+    def test_install_help_shows_flags(self) -> None:
+        """``deeprefine opencode install --help`` shows --project and --user."""
+        result = _run_cli("opencode", "install", "--help")
+        assert result.returncode == 0
+        out = result.stdout
+        assert "--project" in out, f"missing --project flag in help: {out}"
+        assert "--user" in out, f"missing --user flag in help: {out}"
+
+    def test_uninstall_help_shows_flags(self) -> None:
+        """``deeprefine opencode uninstall --help`` shows --project and --user."""
+        result = _run_cli("opencode", "uninstall", "--help")
+        assert result.returncode == 0
+        out = result.stdout
+        assert "--project" in out
+        assert "--user" in out


### PR DESCRIPTION
为 DeepRefine 添加 OpenCode 原生集成，在 harness 层利用 OpenCode 并行子 Agent、模型路由、todowrite、5-Oracle 审查、apply 后验证和证据账本 6 项平台能力，将 Reafiner 工作流升级为并行分派+自动审查+审批门的三阶段架构。
当前版本的 OpenCode 原生支持基础流程；搭配 oh-my-openagent 可获得子 Agent 并行、5-Oracle 审查能力。建议提交前在 README 中注明依赖差异。
## Changes
- 新增 SKILL_OPENCODE.md (605 行)
- 新增 3 个斜杠命令 (/deeprefine, /deeprefine-review, /deeprefine-apply)
- 新增 deeprefine opencode install/uninstall CLI 子命令
- 新增 tests/test_opencode_integration.py (20 个 pytest 用例)
- 编辑 installers.py, cli.py, pyproject.toml, README.md
- 修复 .gitignore 引号语法