### PR TITLE
feat: add wiki refresh support for deeprefine apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ When you run `/deeprefine`, it should follow this order:
 3. refine pending queries sequentially
 4. for refinement-path queries, generate `<refinement>` actions and run `deeprefine review`
 5. stop in dry-run mode and show the review report; do **not** modify `graph.json` yet
-6. only after user approval, run `deeprefine apply` and then `deeprefine loop finish`
+6. only after user approval, run `deeprefine apply --refresh-wiki` and then `deeprefine loop finish`
 
 </details>
 
@@ -159,8 +159,8 @@ Run from your KB project root.
 | `deeprefine loop init --query "..."` | Create `loop_trace_<id>.json` template |
 | `deeprefine loop validate --trace-file T` | Validate trace against Reafiner control flow |
 | `deeprefine review --trace-file T --refinement-file F` | Review proposed actions with HIGH/MEDIUM/LOW evidence labels; no graph write |
-| `deeprefine apply --trace-file T --refinement-file F` | Apply `<refinement>` actions to `graph.json` after approval; refuses LOW by default |
-| `deeprefine apply --allow-low-confidence --trace-file T --refinement-file F` | Override LOW-confidence guard explicitly |
+| `deeprefine apply --refresh-wiki --trace-file T --refinement-file F` | Apply actions and regenerate `graphify-out/wiki` from the refined graph; graph + Wiki are committed together |
+| `deeprefine apply --refresh-wiki --allow-low-confidence --trace-file T --refinement-file F` | Refresh the Wiki while explicitly overriding the LOW-confidence guard |
 | `deeprefine loop finish --trace-file T [--refinement-file F]` | Persist results and mark history refined |
 
 ### Evidence-aware review and safe apply
@@ -181,6 +181,8 @@ GOOD: insert_edge("pretraining/pretraining_CLIP_fine-grained.py::main()", "calls
 ```
 
 `deeprefine apply` refuses LOW-confidence actions by default. Use `--allow-low-confidence` only when the user explicitly accepts the risk.
+
+When the knowledge base was created with Graphify Wiki output, use `--refresh-wiki`. DeepRefine stages the refined graph, regenerates the Wiki with `graphify export wiki`, validates `wiki/index.md`, and only then replaces the production graph and Wiki. If export fails, the existing graph and Wiki remain unchanged.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -23,7 +23,7 @@ Then ask the user for explicit approval.
 Only if the user's **next message** explicitly says to approve/apply/write the graph may you run:
 
 ```bash
-deeprefine apply --trace-file ... --refinement-file ...
+deeprefine apply --refresh-wiki --trace-file ... --refinement-file ...
 deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
@@ -179,10 +179,10 @@ for question in target_queries:
 
         # Follow-up turn only, after the user's next message explicitly approves/apply/write:
         if user explicitly approves and no LOW-confidence action remains:
-            deeprefine apply --trace-file ... --refinement-file ...
+            deeprefine apply --refresh-wiki --trace-file ... --refinement-file ...
             deeprefine loop finish --trace-file ... --refinement-file ...
         if user explicitly accepts LOW-confidence risk in that approval message:
-            deeprefine apply --allow-low-confidence --trace-file ... --refinement-file ...
+            deeprefine apply --refresh-wiki --allow-low-confidence --trace-file ... --refinement-file ...
             deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
@@ -351,9 +351,9 @@ deeprefine review --trace-file ... --refinement-file graphify-out/.deeprefine/re
 # Do NOT run deeprefine apply in the same /deeprefine turn.
 
 # Approval-only follow-up commands, only after the user explicitly says approve/apply:
-deeprefine apply --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+deeprefine apply --refresh-wiki --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 # Optional explicit risk override:
-# deeprefine apply --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+# deeprefine apply --refresh-wiki --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 deeprefine loop finish --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 
 # 9. Repeat step 3..8 until all pending queries are reviewed/finished.

--- a/commands/deeprefine/apply.toml
+++ b/commands/deeprefine/apply.toml
@@ -17,7 +17,7 @@ Requirements:
 2. Require a valid `loop_trace_<query_id>.json` and a refinement action file containing `<refinement>...</refinement>`.
 3. Validate before applying by running `deeprefine loop validate --trace-file <trace> --refinement-file <file>`.
 4. Review before applying by running `deeprefine review --trace-file <trace> --refinement-file <file>` when possible.
-5. Apply only through `deeprefine apply --trace-file <trace> --refinement-file <file>`.
+5. Apply only through `deeprefine apply --refresh-wiki --trace-file <trace> --refinement-file <file>`.
 6. Do not hand-edit `graphify-out/graph.json`.
 7. After applying, finish with `deeprefine loop finish --trace-file <trace> --refinement-file <file>`.
 8. Report every modified artifact and summarize the applied refinement actions.

--- a/deeprefine_skill/SKILL.md
+++ b/deeprefine_skill/SKILL.md
@@ -23,7 +23,7 @@ Then ask the user for explicit approval.
 Only if the user's **next message** explicitly says to approve/apply/write the graph may you run:
 
 ```bash
-deeprefine apply --trace-file ... --refinement-file ...
+deeprefine apply --refresh-wiki --trace-file ... --refinement-file ...
 deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
@@ -179,10 +179,10 @@ for question in target_queries:
 
         # Follow-up turn only, after the user's next message explicitly approves/apply/write:
         if user explicitly approves and no LOW-confidence action remains:
-            deeprefine apply --trace-file ... --refinement-file ...
+            deeprefine apply --refresh-wiki --trace-file ... --refinement-file ...
             deeprefine loop finish --trace-file ... --refinement-file ...
         if user explicitly accepts LOW-confidence risk in that approval message:
-            deeprefine apply --allow-low-confidence --trace-file ... --refinement-file ...
+            deeprefine apply --refresh-wiki --allow-low-confidence --trace-file ... --refinement-file ...
             deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
@@ -351,9 +351,9 @@ deeprefine review --trace-file ... --refinement-file graphify-out/.deeprefine/re
 # Do NOT run deeprefine apply in the same /deeprefine turn.
 
 # Approval-only follow-up commands, only after the user explicitly says approve/apply:
-deeprefine apply --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+deeprefine apply --refresh-wiki --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 # Optional explicit risk override:
-# deeprefine apply --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+# deeprefine apply --refresh-wiki --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 deeprefine loop finish --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
 
 # 9. Repeat step 3..8 until all pending queries are reviewed/finished.

--- a/deeprefine_skill/action_review.py
+++ b/deeprefine_skill/action_review.py
@@ -330,7 +330,7 @@ def render_review_markdown(reviews: list[ActionReview]) -> str:
             lines.append("Suggested replacement:")
             lines.append(f"- {review.suggested_replacement}")
         lines.append("")
-    lines.append("Apply only after review: deeprefine apply --trace-file <trace> --refinement-file <actions>")
+    lines.append("Apply only after review: deeprefine apply --refresh-wiki --trace-file <trace> --refinement-file <actions>")
     return "\n".join(lines).rstrip() + "\n"
 
 

--- a/deeprefine_skill/cli.py
+++ b/deeprefine_skill/cli.py
@@ -397,10 +397,41 @@ def cmd_apply(args: argparse.Namespace) -> int:
         import shutil
 
         shutil.copy2(paths["graph_json"], backup)
-    changes = __import__(
-        "deeprefine_skill.agent_graph", fromlist=["apply_refinement_text"]
-    ).apply_refinement_text(paths["graph_json"], text)
-    print(f"Applied {len(changes)} action(s) to {paths['graph_json']}")
+    if getattr(args, "refresh_wiki", False):
+        from deeprefine_skill.wiki_refresh import (
+            WikiRefreshError,
+            apply_refinement_with_wiki_refresh,
+        )
+
+        try:
+            result = apply_refinement_with_wiki_refresh(
+                graph_path=paths["graph_json"],
+                refinement_text=text,
+                project_root=project,
+            )
+        except WikiRefreshError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        except Exception as exc:
+            print(
+                "Failed to commit graph.json and Wiki together; the transaction "
+                f"was rolled back where possible: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        changes = result.changes
+        if result.stdout.strip():
+            print(result.stdout.strip())
+        print(
+            f"Applied {len(changes)} action(s) to {paths['graph_json']} "
+            f"and refreshed {result.wiki_dir}"
+        )
+    else:
+        changes = __import__(
+            "deeprefine_skill.agent_graph", fromlist=["apply_refinement_text"]
+        ).apply_refinement_text(paths["graph_json"], text)
+        print(f"Applied {len(changes)} action(s) to {paths['graph_json']}")
+
     for c in changes:
         print(f"  - {c}")
     return 0
@@ -912,6 +943,14 @@ def main(argv: list[str] | None = None) -> int:
         "--allow-low-confidence",
         action="store_true",
         help="Apply even when the review contains LOW-confidence actions.",
+    )
+    p_apply.add_argument(
+        "--refresh-wiki",
+        action="store_true",
+        help=(
+            "Regenerate graphify-out/wiki from the refined graph and commit the "
+            "graph + Wiki together; leave both unchanged if refresh fails."
+        ),
     )
     p_apply.add_argument("--project-root", default=None)
     p_apply.set_defaults(func=cmd_apply)

--- a/deeprefine_skill/wiki_refresh.py
+++ b/deeprefine_skill/wiki_refresh.py
@@ -1,0 +1,367 @@
+"""Transactional Graphify wiki refresh for ``deeprefine apply``.
+
+The Graphify wiki is a derived view of ``graphify-out/graph.json``.  Updating
+only the graph leaves the existing Markdown wiki stale.  This module stages a
+refined graph and its regenerated wiki together, then commits both with
+rollback on ordinary filesystem/process failures.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Hashable, Sequence
+
+from deeprefine_skill.agent_graph import apply_refinement_text
+
+
+class WikiRefreshError(RuntimeError):
+    """Raised when Graphify cannot regenerate a valid staged wiki."""
+
+
+@dataclass(frozen=True)
+class WikiRefreshResult:
+    """Result of a successful graph + wiki transaction."""
+
+    changes: list[str]
+    wiki_dir: Path
+    command: tuple[str, ...]
+    stdout: str = ""
+    stderr: str = ""
+
+
+def _graphify_command(executable: str | None = None) -> list[str]:
+    """Resolve Graphify without invoking a shell.
+
+    ``executable`` is primarily useful for tests and custom installations.
+    Otherwise prefer the console script and fall back to ``python -m graphify``
+    when Graphify is installed in the current Python environment but its script
+    directory is not on ``PATH``.
+    """
+    if executable:
+        return [executable]
+
+    found = shutil.which("graphify")
+    if found:
+        return [found]
+
+    try:
+        import importlib.util
+
+        if importlib.util.find_spec("graphify") is not None:
+            return [sys.executable, "-m", "graphify"]
+    except (ImportError, AttributeError, ValueError):
+        pass
+
+    raise WikiRefreshError(
+        "Graphify CLI was not found. Install or upgrade it first, for example: "
+        "`pip install -U graphifyy` (the package has two y's; the command is "
+        "`graphify`)."
+    )
+
+
+def _community_map(graph_data: dict[str, Any]) -> dict[str, list[str]]:
+    """Build exact community membership from the staged graph itself."""
+    communities: dict[str, list[str]] = {}
+    for node in graph_data.get("nodes", []):
+        if not isinstance(node, dict) or node.get("id") is None:
+            continue
+        raw_community = node.get("community")
+        if raw_community is None:
+            continue
+        try:
+            key = str(int(raw_community))
+        except (TypeError, ValueError) as exc:
+            raise WikiRefreshError(
+                "Graphify community identifiers must be integer-like; "
+                f"node {node['id']!r} has community {raw_community!r}."
+            ) from exc
+        communities.setdefault(key, []).append(str(node["id"]))
+    return communities
+
+
+def _stage_graphify_sidecars(source_out: Path, stage_out: Path, graph_data: dict[str, Any]) -> None:
+    """Create sidecars that make the staged wiki follow the staged graph.
+
+    An existing ``.graphify_analysis.json`` may describe the *old* graph.  We
+    therefore regenerate its community membership from node attributes rather
+    than copying stale membership or metrics.  God nodes and cohesion are
+    intentionally omitted so Graphify derives Wiki content from the staged graph.
+    """
+    communities = _community_map(graph_data)
+    if not communities:
+        raise WikiRefreshError(
+            "The refined graph has no node community metadata, so a reliable "
+            "Wiki cannot be generated. Run `graphify cluster-only .` first."
+        )
+
+    analysis: dict[str, Any] = {"communities": communities}
+
+    (stage_out / ".graphify_analysis.json").write_text(
+        json.dumps(analysis, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    labels = source_out / ".graphify_labels.json"
+    if labels.is_file():
+        shutil.copy2(labels, stage_out / labels.name)
+
+
+def _links_key(graph_data: dict[str, Any]) -> str:
+    return "links" if "links" in graph_data else "edges"
+
+
+def _edge_identity(edge: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(edge.get("source")),
+        str(edge.get("target")),
+        str(edge.get("relation", "")),
+    )
+
+
+def _endpoint_key(
+    edge: dict[str, Any], *, directed: bool
+) -> tuple[Hashable, Hashable]:
+    source = str(edge.get("source"))
+    target = str(edge.get("target"))
+    if directed:
+        return source, target
+    return tuple(sorted((source, target)))
+
+
+def _inserted_edges(
+    before: dict[str, Any], after: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Return only link records newly introduced by this refinement."""
+    links_key = _links_key(after)
+    before_counts: dict[tuple[str, str, str], int] = {}
+    for edge in before.get(_links_key(before), []):
+        if isinstance(edge, dict):
+            identity = _edge_identity(edge)
+            before_counts[identity] = before_counts.get(identity, 0) + 1
+
+    inserted: list[dict[str, Any]] = []
+    for edge in after.get(links_key, []):
+        if not isinstance(edge, dict):
+            continue
+        identity = _edge_identity(edge)
+        remaining = before_counts.get(identity, 0)
+        if remaining:
+            before_counts[identity] = remaining - 1
+        else:
+            inserted.append(edge)
+    return inserted
+
+
+def _find_parallel_endpoint_conflicts(
+    before: dict[str, Any], after: dict[str, Any]
+) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+    """Find newly inserted edges whose endpoints already had a relation.
+
+    Graphify 0.9.12 can store parallel links, but its Wiki renderer currently
+    consults only the first edge for an endpoint pair.  Blocking only newly
+    introduced endpoint collisions avoids penalizing historical graph issues.
+    """
+    directed = bool(after.get("directed", before.get("directed", True)))
+    occupied_by_endpoints: dict[tuple[Hashable, Hashable], list[dict[str, Any]]] = {}
+    for edge in before.get(_links_key(before), []):
+        if not isinstance(edge, dict):
+            continue
+        occupied_by_endpoints.setdefault(
+            _endpoint_key(edge, directed=directed), []
+        ).append(edge)
+
+    conflicts: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+    for edge in _inserted_edges(before, after):
+        endpoints = _endpoint_key(edge, directed=directed)
+        occupied = occupied_by_endpoints.get(endpoints)
+        if occupied:
+            conflicts.append((edge, occupied))
+        occupied_by_endpoints.setdefault(endpoints, []).append(edge)
+    return conflicts
+
+
+def _format_edge(edge: dict[str, Any]) -> str:
+    return (
+        f"{edge.get('source')!r} -[{edge.get('relation', '')}]-> "
+        f"{edge.get('target')!r}"
+    )
+
+
+def _assert_wiki_export_can_represent_refinement(
+    before: dict[str, Any], after: dict[str, Any]
+) -> None:
+    conflicts = _find_parallel_endpoint_conflicts(before, after)
+    if not conflicts:
+        return
+
+    lines = [
+        "Graphify Wiki refresh aborted: the current Graphify Wiki exporter does "
+        "not support complete display of parallel relations for the same endpoint "
+        "pair.",
+        "The staged refinement introduced edge(s) whose endpoints already had "
+        "other relation(s) in graph.json, so exporting now would make graph.json "
+        "and the Wiki semantically inconsistent.",
+    ]
+    for inserted, existing_edges in conflicts[:5]:
+        lines.append(f"New edge: {_format_edge(inserted)}")
+        existing_preview = ", ".join(_format_edge(edge) for edge in existing_edges[:3])
+        lines.append(f"Existing edge(s) on same endpoints: {existing_preview}")
+    if len(conflicts) > 5:
+        lines.append(f"... and {len(conflicts) - 5} more conflicting new edge(s).")
+    lines.append(
+        "graph.json and the existing Wiki were left unchanged. DeepRefine will "
+        "not delete, overwrite, or merge existing relations automatically."
+    )
+    raise WikiRefreshError("\n".join(lines))
+
+
+def _run_wiki_export(
+    *,
+    command_prefix: Sequence[str],
+    graph_path: Path,
+    project_root: Path,
+    stage_out: Path,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        *command_prefix,
+        "export",
+        "wiki",
+        "--graph",
+        str(graph_path),
+    ]
+    env = os.environ.copy()
+    # Graphify uses GRAPHIFY_OUT to locate its analysis sidecar.  Pointing it at
+    # the staging directory prevents it from reading stale production metadata.
+    env["GRAPHIFY_OUT"] = str(stage_out)
+    return subprocess.run(
+        command,
+        cwd=str(project_root),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _commit_graph_and_wiki(
+    *,
+    staged_graph: Path,
+    staged_wiki: Path,
+    graph_path: Path,
+    wiki_dir: Path,
+    transaction_root: Path,
+) -> None:
+    """Replace graph and wiki, rolling both back if an operation fails."""
+    old_graph = transaction_root / "previous-graph.json"
+    old_wiki = transaction_root / "previous-wiki"
+    shutil.copy2(graph_path, old_graph)
+
+    graph_replaced = False
+    old_wiki_moved = False
+    new_wiki_installed = False
+    try:
+        os.replace(staged_graph, graph_path)
+        graph_replaced = True
+
+        if wiki_dir.exists():
+            os.replace(wiki_dir, old_wiki)
+            old_wiki_moved = True
+
+        os.replace(staged_wiki, wiki_dir)
+        new_wiki_installed = True
+    except Exception:
+        # Remove a partially installed new wiki before restoring the old one.
+        if new_wiki_installed and wiki_dir.exists():
+            shutil.rmtree(wiki_dir, ignore_errors=True)
+        if old_wiki_moved and old_wiki.exists() and not wiki_dir.exists():
+            os.replace(old_wiki, wiki_dir)
+        if graph_replaced and old_graph.exists():
+            os.replace(old_graph, graph_path)
+        raise
+
+
+def apply_refinement_with_wiki_refresh(
+    *,
+    graph_path: Path,
+    refinement_text: str,
+    project_root: Path,
+    graphify_executable: str | None = None,
+) -> WikiRefreshResult:
+    """Stage, validate, and commit a refined graph together with its Wiki.
+
+    The production graph and Wiki are not changed unless Graphify exits
+    successfully and creates ``wiki/index.md`` from the staged graph.
+    """
+    graph_path = graph_path.resolve()
+    project_root = project_root.resolve()
+    graphify_out = graph_path.parent
+    wiki_dir = graphify_out / "wiki"
+    command_prefix = _graphify_command(graphify_executable)
+
+    transaction_parent = graphify_out / ".deeprefine"
+    transaction_parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(
+        prefix="wiki-refresh-", dir=transaction_parent
+    ) as tmp:
+        transaction_root = Path(tmp)
+        stage_out = transaction_root / "graphify-out"
+        stage_out.mkdir(parents=True)
+        staged_graph = stage_out / "graph.json"
+        shutil.copy2(graph_path, staged_graph)
+
+        original_graph_data = json.loads(graph_path.read_text(encoding="utf-8"))
+        changes = apply_refinement_text(staged_graph, refinement_text)
+        graph_data = json.loads(staged_graph.read_text(encoding="utf-8"))
+        _assert_wiki_export_can_represent_refinement(original_graph_data, graph_data)
+        _stage_graphify_sidecars(graphify_out, stage_out, graph_data)
+
+        completed = _run_wiki_export(
+            command_prefix=command_prefix,
+            graph_path=staged_graph,
+            project_root=project_root,
+            stage_out=stage_out,
+        )
+        command = (
+            *command_prefix,
+            "export",
+            "wiki",
+            "--graph",
+            str(staged_graph),
+        )
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "unknown error").strip()
+            raise WikiRefreshError(
+                "Graphify Wiki refresh failed; graph.json and the existing Wiki "
+                f"were left unchanged. Command: {' '.join(command)}\n{detail}"
+            )
+
+        staged_wiki = stage_out / "wiki"
+        index_path = staged_wiki / "index.md"
+        if not index_path.is_file():
+            raise WikiRefreshError(
+                "Graphify exited successfully but did not create wiki/index.md; "
+                "graph.json and the existing Wiki were left unchanged."
+            )
+
+        _commit_graph_and_wiki(
+            staged_graph=staged_graph,
+            staged_wiki=staged_wiki,
+            graph_path=graph_path,
+            wiki_dir=wiki_dir,
+            transaction_root=transaction_root,
+        )
+
+    return WikiRefreshResult(
+        changes=changes,
+        wiki_dir=wiki_dir,
+        command=tuple(command),
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )

--- a/tests/test_wiki_refresh.py
+++ b/tests/test_wiki_refresh.py
@@ -1,0 +1,393 @@
+"""Tests for ``deeprefine apply --refresh-wiki`` staging and rollback."""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from deeprefine_skill.cli import main
+from deeprefine_skill.wiki_refresh import (
+    WikiRefreshError,
+    apply_refinement_with_wiki_refresh,
+)
+
+
+def _make_project(
+    tmp_path: Path, *, directed: bool = True
+) -> tuple[Path, Path, Path]:
+    project = tmp_path / "project"
+    out = project / "graphify-out"
+    wiki = out / "wiki"
+    wiki.mkdir(parents=True)
+
+    graph = out / "graph.json"
+    graph.write_text(
+        json.dumps(
+            {
+                "directed": directed,
+                "multigraph": False,
+                "nodes": [
+                    {"id": "a", "label": "Alpha", "community": 0},
+                    {"id": "b", "label": "Beta", "community": 0},
+                    {"id": "c", "label": "Gamma", "community": 0},
+                    {"id": "d", "label": "Delta", "community": 0},
+                ],
+                "links": [
+                    {
+                        "source": "a",
+                        "target": "b",
+                        "relation": "related_to",
+                        "confidence": "EXTRACTED",
+                    }
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (wiki / "index.md").write_text("old wiki", encoding="utf-8")
+    (wiki / "community-0.md").write_text("old community", encoding="utf-8")
+    (out / ".graphify_labels.json").write_text(
+        json.dumps({"0": "Core"}), encoding="utf-8"
+    )
+    return project, graph, wiki
+
+
+def _graph_hash(graph: Path) -> str:
+    return hashlib.sha256(graph.read_bytes()).hexdigest()
+
+
+def _wiki_snapshot(wiki: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(wiki)): path.read_text(encoding="utf-8")
+        for path in sorted(wiki.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _assert_no_wiki_refresh_temps(graph: Path) -> None:
+    temp_parent = graph.parent / ".deeprefine"
+    assert not list(temp_parent.glob("wiki-refresh-*"))
+
+
+def _fake_successful_export(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(command, *, cwd, env, text, capture_output, check):
+        stage_out = Path(env["GRAPHIFY_OUT"])
+        staged_graph = Path(command[command.index("--graph") + 1])
+        graph_data = json.loads(staged_graph.read_text(encoding="utf-8"))
+        stage_wiki = stage_out / "wiki"
+        stage_wiki.mkdir()
+        (stage_wiki / "index.md").write_text(
+            f"wiki generated with {len(graph_data['links'])} links",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0, "Wiki: ok\n", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+def test_refresh_commits_graph_and_wiki_together(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path)
+    observed_analysis: dict = {}
+
+    def fake_run(command, *, cwd, env, text, capture_output, check):
+        assert command[:3] == ["/fake/graphify", "export", "wiki"]
+        assert Path(cwd) == project
+        stage_out = Path(env["GRAPHIFY_OUT"])
+        staged_graph = Path(command[command.index("--graph") + 1])
+        graph_data = json.loads(staged_graph.read_text(encoding="utf-8"))
+        observed_analysis.update(
+            json.loads(
+                (stage_out / ".graphify_analysis.json").read_text(encoding="utf-8")
+            )
+        )
+        stage_wiki = stage_out / "wiki"
+        stage_wiki.mkdir()
+        label = graph_data["nodes"][0]["label"]
+        (stage_wiki / "index.md").write_text(
+            f"wiki generated from {label}", encoding="utf-8"
+        )
+        return subprocess.CompletedProcess(command, 0, "Wiki: ok\n", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = apply_refinement_with_wiki_refresh(
+        graph_path=graph,
+        refinement_text=(
+            '<refinement>replace_node("Alpha", "Alpha Updated")</refinement>'
+        ),
+        project_root=project,
+        graphify_executable="/fake/graphify",
+    )
+
+    updated = json.loads(graph.read_text(encoding="utf-8"))
+    assert updated["nodes"][0]["label"] == "Alpha Updated"
+    assert (wiki / "index.md").read_text(encoding="utf-8") == (
+        "wiki generated from Alpha Updated"
+    )
+    assert observed_analysis["communities"] == {"0": ["a", "b", "c", "d"]}
+    assert result.changes == ["replace_node(Alpha, Alpha Updated)"]
+    assert result.wiki_dir == wiki
+
+
+def test_refresh_allows_new_edge_for_previously_unrelated_endpoints(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path)
+    _fake_successful_export(monkeypatch)
+
+    result = apply_refinement_with_wiki_refresh(
+        graph_path=graph,
+        refinement_text=(
+            '<refinement>insert_edge("Gamma", "uses", "Delta")</refinement>'
+        ),
+        project_root=project,
+        graphify_executable="/fake/graphify",
+    )
+
+    updated = json.loads(graph.read_text(encoding="utf-8"))
+    assert any(
+        link["source"] == "c" and link["target"] == "d" and link["relation"] == "uses"
+        for link in updated["links"]
+    )
+    assert (wiki / "index.md").read_text(encoding="utf-8") == (
+        "wiki generated with 2 links"
+    )
+    assert result.changes == ["insert_edge(Gamma, uses, Delta)"]
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_refresh_does_not_block_historical_parallel_edges_for_unrelated_insert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path)
+    raw = json.loads(graph.read_text(encoding="utf-8"))
+    raw["links"].append(
+        {
+            "source": "a",
+            "target": "b",
+            "relation": "imports_from",
+            "confidence": "EXTRACTED",
+        }
+    )
+    graph.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+    _fake_successful_export(monkeypatch)
+
+    result = apply_refinement_with_wiki_refresh(
+        graph_path=graph,
+        refinement_text=(
+            '<refinement>insert_edge("Gamma", "uses", "Delta")</refinement>'
+        ),
+        project_root=project,
+        graphify_executable="/fake/graphify",
+    )
+
+    assert result.changes == ["insert_edge(Gamma, uses, Delta)"]
+    assert (wiki / "index.md").read_text(encoding="utf-8") == (
+        "wiki generated with 3 links"
+    )
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_refresh_rejects_new_parallel_relation_and_leaves_outputs_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path)
+    original_graph_hash = _graph_hash(graph)
+    original_wiki = _wiki_snapshot(wiki)
+    _fake_successful_export(monkeypatch)
+
+    with pytest.raises(WikiRefreshError, match="parallel relations"):
+        apply_refinement_with_wiki_refresh(
+            graph_path=graph,
+            refinement_text=(
+                '<refinement>insert_edge("Alpha", "uses_data_module", "Beta")'
+                "</refinement>"
+            ),
+            project_root=project,
+            graphify_executable="/fake/graphify",
+        )
+
+    assert _graph_hash(graph) == original_graph_hash
+    assert _wiki_snapshot(wiki) == original_wiki
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_refresh_rejects_two_new_parallel_relations_in_same_refinement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path)
+    original_graph_hash = _graph_hash(graph)
+    original_wiki = _wiki_snapshot(wiki)
+    _fake_successful_export(monkeypatch)
+
+    with pytest.raises(WikiRefreshError, match="parallel relations"):
+        apply_refinement_with_wiki_refresh(
+            graph_path=graph,
+            refinement_text=(
+                '<refinement>insert_edge("Gamma", "uses", "Delta")|'
+                'insert_edge("Gamma", "produces", "Delta")</refinement>'
+            ),
+            project_root=project,
+            graphify_executable="/fake/graphify",
+        )
+
+    assert _graph_hash(graph) == original_graph_hash
+    assert _wiki_snapshot(wiki) == original_wiki
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_refresh_rejects_reversed_parallel_relation_when_graph_is_undirected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path, directed=False)
+    original_graph_hash = _graph_hash(graph)
+    original_wiki = _wiki_snapshot(wiki)
+    _fake_successful_export(monkeypatch)
+
+    with pytest.raises(WikiRefreshError, match="parallel relations"):
+        apply_refinement_with_wiki_refresh(
+            graph_path=graph,
+            refinement_text=(
+                '<refinement>insert_edge("Beta", "uses_data_module", "Alpha")'
+                "</refinement>"
+            ),
+            project_root=project,
+            graphify_executable="/fake/graphify",
+        )
+
+    assert _graph_hash(graph) == original_graph_hash
+    assert _wiki_snapshot(wiki) == original_wiki
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_refresh_allows_reversed_relation_when_graph_is_directed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path, directed=True)
+    _fake_successful_export(monkeypatch)
+
+    result = apply_refinement_with_wiki_refresh(
+        graph_path=graph,
+        refinement_text=(
+            '<refinement>insert_edge("Beta", "uses_data_module", "Alpha")'
+            "</refinement>"
+        ),
+        project_root=project,
+        graphify_executable="/fake/graphify",
+    )
+
+    updated = json.loads(graph.read_text(encoding="utf-8"))
+    assert any(
+        link["source"] == "b"
+        and link["target"] == "a"
+        and link["relation"] == "uses_data_module"
+        for link in updated["links"]
+    )
+    assert result.changes == ["insert_edge(Beta, uses_data_module, Alpha)"]
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_refresh_allows_two_new_reversed_relations_in_same_directed_refinement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path, directed=True)
+    _fake_successful_export(monkeypatch)
+
+    result = apply_refinement_with_wiki_refresh(
+        graph_path=graph,
+        refinement_text=(
+            '<refinement>insert_edge("Gamma", "uses", "Delta")|'
+            'insert_edge("Delta", "produces", "Gamma")</refinement>'
+        ),
+        project_root=project,
+        graphify_executable="/fake/graphify",
+    )
+
+    updated = json.loads(graph.read_text(encoding="utf-8"))
+    assert any(
+        link["source"] == "c" and link["target"] == "d" and link["relation"] == "uses"
+        for link in updated["links"]
+    )
+    assert any(
+        link["source"] == "d"
+        and link["target"] == "c"
+        and link["relation"] == "produces"
+        for link in updated["links"]
+    )
+    assert result.changes == [
+        "insert_edge(Gamma, uses, Delta)",
+        "insert_edge(Delta, produces, Gamma)",
+    ]
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_apply_refresh_wiki_returns_nonzero_for_parallel_relation_without_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project, graph, wiki = _make_project(tmp_path)
+    original_graph_hash = _graph_hash(graph)
+    original_wiki = _wiki_snapshot(wiki)
+    actions = tmp_path / "actions.txt"
+    actions.write_text(
+        '<refinement>insert_edge("Alpha", "uses_data_module", "Beta")</refinement>',
+        encoding="utf-8",
+    )
+    fake_bin = tmp_path / "graphify"
+    fake_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_bin.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}")
+
+    code = main(
+        [
+            "apply",
+            "--refresh-wiki",
+            "--skip-trace-check",
+            "--allow-low-confidence",
+            "--refinement-file",
+            str(actions),
+            "--project-root",
+            str(project),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "Graphify Wiki exporter" in captured.err
+    assert "parallel relations" in captured.err
+    assert _graph_hash(graph) == original_graph_hash
+    assert _wiki_snapshot(wiki) == original_wiki
+    _assert_no_wiki_refresh_temps(graph)
+
+
+def test_refresh_failure_leaves_graph_and_wiki_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, graph, wiki = _make_project(tmp_path)
+    original_graph = graph.read_text(encoding="utf-8")
+    original_wiki = (wiki / "index.md").read_text(encoding="utf-8")
+
+    def fake_run(command, *, cwd, env, text, capture_output, check):
+        return subprocess.CompletedProcess(command, 1, "", "export failed")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(WikiRefreshError, match="left unchanged"):
+        apply_refinement_with_wiki_refresh(
+            graph_path=graph,
+            refinement_text=(
+                '<refinement>replace_node("Alpha", "Alpha Updated")</refinement>'
+            ),
+            project_root=project,
+            graphify_executable="/fake/graphify",
+        )
+
+    assert graph.read_text(encoding="utf-8") == original_graph
+    assert (wiki / "index.md").read_text(encoding="utf-8") == original_wiki


### PR DESCRIPTION
Summary
This PR adds `--refresh-wiki` support to `deeprefine apply` to keep Graphify graph data and generated Wiki synchronized after refinement.

Previously, `deeprefine apply` only updated `graph.json`. When the Wiki was generated from Graphify, later graph changes could make the Wiki inconsistent. This PR introduces a safer refresh workflow that updates both artifacts together.

Changes

- Add `deeprefine apply --refresh-wiki`
- Introduce a staged refinement workflow:
  - apply refinement actions on a temporary graph
  - regenerate Graphify Wiki from the refined graph
  - replace production graph and Wiki only after successful refresh
- Keep existing `graph.json` and Wiki unchanged when refresh fails
- Add detection for parallel relations that cannot be correctly represented by the current Graphify Wiki exporter
- Abort unsafe Wiki refreshes instead of producing inconsistent Wiki content
- Update DeepRefine instructions and command examples to use `--refresh-wiki` by default
