### PR TITLE
sync with upstream: Reafiner → DeepRefine rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ build/
 
 # Personal working documents — kept locally, not distributed
 docs/tmp/
-CLAUDE.local.md
+.github/skills/
 .omo/
 graphify-out/
 venv/ 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@ Use the `deeprefine` skill when the user asks to refine, diagnose, debug, improv
 ## Core behavior
 
 1. Prefer the agent-native DeepRefine loop over the terminal-only `deeprefine refine` command unless the user explicitly requests CLI / FAISS mode.
-2. Follow the same control flow as `Reafiner.refine()` from DeepRefine.
+2. Follow the same control flow as `DeepRefine.refine()` from DeepRefine.
 3. Import Graphify memory with `deeprefine history sync-memory` when running the default queue workflow.
 4. Process pending history entries one by one.
 5. Use Graphify query results and k-hop expansion over `graphify-out/graph.json` as retrieval evidence.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Run from your KB project root.
 | `deeprefine history sync-memory` | Import `graphify-out/memory/query_*.md` into DeepRefine history |
 | `deeprefine history list --pending` | Show unrefined queue |
 | `deeprefine loop init --query "..."` | Create `loop_trace_<id>.json` template |
-| `deeprefine loop validate --trace-file T` | Validate trace against Reafiner control flow |
+| `deeprefine loop validate --trace-file T` | Validate trace against DeepRefine control flow |
 | `deeprefine review --trace-file T --refinement-file F` | Review proposed actions with HIGH/MEDIUM/LOW evidence labels; no graph write |
 | `deeprefine apply --trace-file T --refinement-file F` | Apply `<refinement>` actions to `graph.json` after approval; refuses LOW by default |
 | `deeprefine apply --allow-low-confidence --trace-file T --refinement-file F` | Override LOW-confidence guard explicitly |
@@ -192,7 +192,7 @@ GOOD: insert_edge("pretraining/pretraining_CLIP_fine-grained.py::main()", "calls
 DeepRefine works as a Codex skill. The installer writes the Codex-specific
 skill file to `.agents/skills/deeprefine/SKILL.md` and UI metadata to
 `.agents/skills/deeprefine/agents/openai.yaml`. It also installs focused
-references under `.agents/skills/deeprefine/references/` for the Reafiner
+references under `.agents/skills/deeprefine/references/` for the refinement
 workflow, LLM prompts, and trace/command details.
 
 ### One-time setup
@@ -225,7 +225,7 @@ $deeprefine
 $deeprefine
 ```
 
-Codex runs the full agent-native Reafiner loop for pending queries, stops after
+Codex runs the full agent-native refinement loop for pending queries, stops after
 `deeprefine review`, and presents the HIGH/MEDIUM/LOW report. Reply with an
 explicit apply/approve message only after reviewing the proposed actions.
 
@@ -267,7 +267,7 @@ keyword-based mode detection in the SKILL.md preamble:
 
 | Mode | Trigger keywords | Behavior |
 |------|-----------------|----------|
-| **Full workflow** | `/deeprefine`, "refine", "improve", "fix" | Full Reafiner loop; stops after dry-run review; asks for approval |
+| **Full workflow** | `/deeprefine`, "refine", "improve", "fix" | Full refinement loop; stops after dry-run review; asks for approval |
 | **Review only** | "review", "check", "audit", "inspect", "dry-run" | Reads trace + refinement file; shows HIGH/MEDIUM/LOW report; no graph writes |
 | **Apply only** | "approve", "apply", "write", "go ahead" | Runs `deeprefine apply` only after a prior review; requires explicit user approval in the current message |
 
@@ -277,7 +277,7 @@ keyword-based mode detection in the SKILL.md preamble:
 /deeprefine
 ```
 
-The agent runs the full Reafiner loop for all pending queries.  For
+The agent runs the full refinement loop for all pending queries.  For
 refinement-path queries, it stops after the dry-run review and asks:
 
 ```text
@@ -447,7 +447,7 @@ deeprefine opencode uninstall --project
 DeepRefine works as a Claude Code Agent Skill. The installer writes the
 Claude-specific skill file to `.claude/skills/deeprefine/SKILL.md`, along with
 independently maintained references under
-`.claude/skills/deeprefine/references/` for the Reafiner workflow, LLM
+`.claude/skills/deeprefine/references/` for the refinement workflow, LLM
 prompts, and trace/command details.
 
 ### One-time setup
@@ -479,7 +479,7 @@ to refresh the local skill files. Restart Claude Code, then invoke:
 /deeprefine
 ```
 
-Claude Code runs the full Reafiner loop for pending queries, stops after
+Claude Code runs the full refinement loop for pending queries, stops after
 `deeprefine review`, and presents the HIGH/MEDIUM/LOW report. Reply with an
 explicit apply/approve message only after reviewing the proposed actions.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: deeprefine
 description: >-
-  Agent-native DeepRefine Reafiner loop — same control flow as Reafiner.refine(),
+  Agent-native DeepRefine refinement loop — same control flow as DeepRefine.refine(),
   graphify search instead of FAISS, session LLM, dry-run review before approved graph writes.
 disable-model-invocation: false
 ---
 
-# DeepRefine — Agent Reafiner loop (strict)
+# DeepRefine — Agent refinement loop (strict)
 
 ## Default safety policy: dry-run only
 
@@ -31,7 +31,7 @@ Do not treat generation of `<refinement>` actions as approval. Do not treat a va
 
 ---
 
-You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
+You **MUST** implement the **same control flow** as `DeepRefine.refine()` in DeepRefine (`autorefiner/src/deeprefine.py`).
 
 | Component | Agent mode | CLI `deeprefine refine` |
 |-----------|------------|-------------------------|
@@ -60,7 +60,7 @@ If validation fails, **fix the trace and re-run the missing step** — do not by
 
 ---
 
-## Constants (match `refine_runner.py` / Reafiner)
+## Constants (match `refine_runner.py` / DeepRefine)
 
 ```text
 MAX_HOPS = 4
@@ -103,12 +103,12 @@ Run `deeprefine loop validate --trace-file ...` after abduction and before `revi
    - preserve file order
 3. If pending queue is non-empty: set `target_queries = pending_queue`.
 4. If pending queue is empty: set `target_queries = [current session question]`.
-5. Run the full Reafiner loop for **each** query in `target_queries`, one by one.
+5. Run the full refinement loop for **each** query in `target_queries`, one by one.
 6. For early-exit queries, finish immediately. For refinement-path queries, generate review output and wait for user approval before `apply` + `loop finish`.
 
 ---
 
-## Control flow (must match `Reafiner.refine()`)
+## Control flow (must match `DeepRefine.refine()`)
 
 Pseudocode — follow **exactly**:
 
@@ -150,7 +150,7 @@ for question in target_queries:
         if answerable:
             BREAK   # stop hop loop
 
-    # --- same branch as Reafiner.refine() line 314+ ---
+    # --- same branch as DeepRefine.refine() line 314+ ---
     if len(interaction_history) <= 1:
         # Early exit: first hop was answerable — NO graph refinement
         set trace.early_exit = true
@@ -186,7 +186,7 @@ for question in target_queries:
             deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
-**Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+**Critical refinement rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
 
 **Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
 
@@ -255,7 +255,7 @@ Analyze the reasons of the unanswerable questions based on the given interaction
 Interaction history: {interaction_history}
 ```
 
-`{interaction_history}` format (same as Reafiner):
+`{interaction_history}` format (same as DeepRefine):
 
 ```text
 Step1:
@@ -307,7 +307,7 @@ Copy and tick each item in your final message:
 [ ] Step 1: graphify query executed (evidence in trace)
 [ ] Each step: <judge>Yes|No</judge> shown in chat
 [ ] Hops stopped on Yes OR reached MAX_HOPS
-[ ] early_exit OR (abduction + refinement) per Reafiner branch
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
 [ ] deeprefine loop validate passed
 [ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
 [ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message

--- a/deeprefine_skill/SKILL.md
+++ b/deeprefine_skill/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: deeprefine
 description: >-
-  Agent-native DeepRefine Reafiner loop — same control flow as Reafiner.refine(),
+  Agent-native DeepRefine refinement loop — same control flow as DeepRefine.refine(),
   graphify search instead of FAISS, session LLM, dry-run review before approved graph writes.
 disable-model-invocation: false
 ---
 
-# DeepRefine — Agent Reafiner loop (strict)
+# DeepRefine — Agent refinement loop (strict)
 
 ## Default safety policy: dry-run only
 
@@ -31,7 +31,7 @@ Do not treat generation of `<refinement>` actions as approval. Do not treat a va
 
 ---
 
-You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
+You **MUST** implement the **same control flow** as `DeepRefine.refine()` in DeepRefine (`autorefiner/src/deeprefine.py`).
 
 | Component | Agent mode | CLI `deeprefine refine` |
 |-----------|------------|-------------------------|
@@ -60,7 +60,7 @@ If validation fails, **fix the trace and re-run the missing step** — do not by
 
 ---
 
-## Constants (match `refine_runner.py` / Reafiner)
+## Constants (match `refine_runner.py` / DeepRefine)
 
 ```text
 MAX_HOPS = 4
@@ -103,12 +103,12 @@ Run `deeprefine loop validate --trace-file ...` after abduction and before `revi
    - preserve file order
 3. If pending queue is non-empty: set `target_queries = pending_queue`.
 4. If pending queue is empty: set `target_queries = [current session question]`.
-5. Run the full Reafiner loop for **each** query in `target_queries`, one by one.
+5. Run the full refinement loop for **each** query in `target_queries`, one by one.
 6. For early-exit queries, finish immediately. For refinement-path queries, generate review output and wait for user approval before `apply` + `loop finish`.
 
 ---
 
-## Control flow (must match `Reafiner.refine()`)
+## Control flow (must match `DeepRefine.refine()`)
 
 Pseudocode — follow **exactly**:
 
@@ -150,7 +150,7 @@ for question in target_queries:
         if answerable:
             BREAK   # stop hop loop
 
-    # --- same branch as Reafiner.refine() line 314+ ---
+    # --- same branch as DeepRefine.refine() line 314+ ---
     if len(interaction_history) <= 1:
         # Early exit: first hop was answerable — NO graph refinement
         set trace.early_exit = true
@@ -186,7 +186,7 @@ for question in target_queries:
             deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
-**Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+**Critical refinement rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
 
 **Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
 
@@ -255,7 +255,7 @@ Analyze the reasons of the unanswerable questions based on the given interaction
 Interaction history: {interaction_history}
 ```
 
-`{interaction_history}` format (same as Reafiner):
+`{interaction_history}` format (same as DeepRefine):
 
 ```text
 Step1:
@@ -307,7 +307,7 @@ Copy and tick each item in your final message:
 [ ] Step 1: graphify query executed (evidence in trace)
 [ ] Each step: <judge>Yes|No</judge> shown in chat
 [ ] Hops stopped on Yes OR reached MAX_HOPS
-[ ] early_exit OR (abduction + refinement) per Reafiner branch
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
 [ ] deeprefine loop validate passed
 [ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
 [ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message

--- a/deeprefine_skill/SKILL_COPILOT.md
+++ b/deeprefine_skill/SKILL_COPILOT.md
@@ -1,17 +1,17 @@
 ---
 name: deeprefine
 description: >-
-  Refine a graphify knowledge graph using the DeepRefine Reafiner algorithm.
+  Refine a graphify knowledge graph using the DeepRefine refinement algorithm.
   Use when the user asks to refine their KG, improve retrieval quality, fix
   incomplete or incorrect knowledge graph triples, or explicitly invokes
-  /deeprefine.  Implements the same control flow as Reafiner.refine() with
+  /deeprefine.  Implements the same control flow as DeepRefine.refine() with
   graphify search instead of FAISS, session LLM for judgement, and dry-run
   review before approved graph writes.
 allowed-tools: shell
 license: MIT
 ---
 
-# DeepRefine — Agent Reafiner Loop (Copilot CLI)
+# DeepRefine — Agent Refinement Loop (Copilot CLI)
 
 > **Platform**: This is the Copilot CLI variant of the DeepRefine agent skill.
 > Shell commands (`deeprefine`, `graphify`) are pre-approved via
@@ -33,7 +33,7 @@ refine / improve / fix / diagnose the knowledge graph.
 **Behavior**:
 
 1. `deeprefine history sync-memory`
-2. Process all pending queries through the full Reafiner loop
+2. Process all pending queries through the full refinement loop
 3. For early-exit queries: `loop finish` immediately
 4. For refinement-path queries: `validate` → `review` → **HARD STOP**
 5. Present the review (HIGH/MEDIUM/LOW labels, evidence, warnings) to the user
@@ -114,8 +114,8 @@ valid trace as approval.  Do not apply in the same `/deeprefine` turn.
 
 ---
 
-You **MUST** implement the **same control flow** as `Reafiner.refine()` in
-DeepRefine (`autorefiner/src/reafiner.py`).
+You **MUST** implement the **same control flow** as `DeepRefine.refine()` in
+DeepRefine (`autorefiner/src/deeprefine.py`).
 
 | Component    | Agent mode                                                    | CLI `deeprefine refine`      |
 |--------------|---------------------------------------------------------------|------------------------------|
@@ -149,7 +149,7 @@ bypass with `--skip-trace-check`.
 
 ---
 
-## Constants (match `refine_runner.py` / Reafiner)
+## Constants (match `refine_runner.py` / DeepRefine)
 
 ```text
 MAX_HOPS = 4
@@ -194,7 +194,7 @@ the latest one.
    - preserve file order
 3. If pending queue is non-empty: set `target_queries = pending_queue`.
 4. If pending queue is empty: set `target_queries = [current session question]`.
-5. Run the full Reafiner loop for **each** query in `target_queries`, one by
+5. Run the full refinement loop for **each** query in `target_queries`, one by
    one.
 6. For early-exit queries, finish immediately.  For refinement-path queries,
    generate review output and wait for user approval before `apply` +
@@ -202,7 +202,7 @@ the latest one.
 
 ---
 
-## Control Flow (must match `Reafiner.refine()`)
+## Control Flow (must match `DeepRefine.refine()`)
 
 Pseudocode — follow **exactly**:
 
@@ -244,7 +244,7 @@ for question in target_queries:
         if answerable:
             BREAK   # stop hop loop
 
-    # --- same branch as Reafiner.refine() line 314+ ---
+    # --- same branch as DeepRefine.refine() line 314+ ---
     if len(interaction_history) <= 1:
         # Early exit: first hop was answerable — NO graph refinement
         set trace.early_exit = true
@@ -280,7 +280,7 @@ for question in target_queries:
             deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
-**Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`,
+**Critical refinement rule:** refinement runs when `len(interaction_history) > 1`,
 not only when all judgements are `No`.
 
 **Safe-review rule:** a refinement path is dry-run by default.  Generating
@@ -357,7 +357,7 @@ Analyze the reasons of the unanswerable questions based on the given interaction
 Interaction history: {interaction_history}
 ```
 
-`{interaction_history}` format (same as Reafiner):
+`{interaction_history}` format (same as DeepRefine):
 
 ```text
 Step1:
@@ -410,7 +410,7 @@ Copy and tick each item in your final message:
 [ ] Step 1: graphify query executed (evidence in trace)
 [ ] Each step: <judge>Yes|No</judge> shown in chat
 [ ] Hops stopped on Yes OR reached MAX_HOPS
-[ ] early_exit OR (abduction + refinement) per Reafiner branch
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
 [ ] deeprefine loop validate passed
 [ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
 [ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message

--- a/deeprefine_skill/SKILL_OPENCODE.md
+++ b/deeprefine_skill/SKILL_OPENCODE.md
@@ -1,9 +1,9 @@
 ---
 name: deeprefine
-description: "Agent-native DeepRefine Reafiner loop for Graphify knowledge graphs with 6 OpenCode-native optimizations — parallel query processing, phase-specific model routing, structured progress tracking, 5-oracle parallel review, post-apply verification, and evidence ledger."
+description: "Agent-native DeepRefine refinement loop for Graphify knowledge graphs with 6 OpenCode-native optimizations"
 ---
 
-# DeepRefine — Agent Reafiner loop (OpenCode optimized)
+# DeepRefine — Agent refinement loop (OpenCode optimized)
 
 ## Default safety policy: dry-run only
 
@@ -43,7 +43,7 @@ This harness leverages 6 OpenCode platform capabilities unavailable in Cursor or
 
 ---
 
-You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
+You **MUST** implement the **same control flow** as `DeepRefine.refine()` in DeepRefine (`autorefiner/src/deeprefine.py`).
 
 | Component | Agent mode | CLI `deeprefine refine` |
 |-----------|------------|-------------------------|
@@ -88,7 +88,7 @@ If validation fails, **fix the trace and re-run the missing step** — do not by
 
 ---
 
-## Constants (match `refine_runner.py` / Reafiner)
+## Constants (match `refine_runner.py` / DeepRefine)
 
 ```text
 MAX_HOPS = 4
@@ -175,7 +175,7 @@ For EACH question in target_queries, launch a parallel subagent:
                Do NOT launch any subagents. Do NOT review. Just save and return.")
 ```
 
-Each subagent independently runs the core Reafiner loop (query → judge → k-hop → abduction → refinement → save file). For early-exit queries, finish immediately. For refinement-path queries, save the actions file and return.
+Each subagent independently runs the core refinement loop (query → judge → k-hop → abduction → refinement → save file). For early-exit queries, finish immediately. For refinement-path queries, save the actions file and return.
 
 **Stage 2 — Centralized Oracle review (main agent collects files, launches reviews):** After ALL Stage 1 subagents complete, the main agent collects all generated refinement_actions_*.txt files. For EACH file, launch 5 oracle reviews (see "5-Oracle parallel review" section). Oracles read the file and return APPROVE/REJECT.
 
@@ -185,7 +185,7 @@ Do NOT make sub-agents call task() — always launch oracles from the main agent
 
 ---
 
-## Control flow (must match `Reafiner.refine()`)
+## Control flow (must match `DeepRefine.refine()`)
 
 Pseudocode — follow **exactly**:
 
@@ -236,7 +236,7 @@ Within each subagent, for its assigned question (Stage 1 ONLY — query → refi
         if answerable:
             BREAK   # stop hop loop
 
-    # --- same branch as Reafiner.refine() line 314+ ---
+    # --- same branch as DeepRefine.refine() line 314+ ---
     if len(interaction_history) <= 1:
         # Early exit: first hop was answerable — NO graph refinement
         set trace.early_exit = true
@@ -310,7 +310,7 @@ if any oracle returned REJECT and user has not explicitly overridden:
     Do NOT apply until user decision
 ```
 
-**Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+**Critical refinement rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
 
 **Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
 
@@ -427,7 +427,7 @@ Analyze the reasons of the unanswerable questions based on the given interaction
 Interaction history: {interaction_history}
 ```
 
-`{interaction_history}` format (same as Reafiner):
+`{interaction_history}` format (same as DeepRefine):
 
 ```text
 Step1:

--- a/deeprefine_skill/__init__.py
+++ b/deeprefine_skill/__init__.py
@@ -1,3 +1,3 @@
-"""DeepRefine agent skill: refine graphify graph.json via Reafiner."""
+"""DeepRefine agent skill: refine graphify graph.json via the DeepRefine loop."""
 
 __version__ = "0.2.0"

--- a/deeprefine_skill/adapter_graphify.py
+++ b/deeprefine_skill/adapter_graphify.py
@@ -57,7 +57,7 @@ def _entity_nodes(kg: nx.DiGraph) -> list[str]:
     ]
 
 
-def build_reafiner_data(
+def build_deeprefine_data(
     kg: nx.DiGraph,
     sentence_encoder: BaseEmbeddingModel,
     *,
@@ -136,14 +136,14 @@ def load_or_build_data(
         with cache_pkl.open("rb") as f:
             bundle = pickle.load(f)
         raw = bundle["graphify_raw"]
-        data = bundle["reafiner_data"]
+        data = bundle["deeprefine_data"]
         return raw, data
 
     raw, kg = load_graphify_json(graph_path)
-    data = build_reafiner_data(kg, sentence_encoder)
+    data = build_deeprefine_data(kg, sentence_encoder)
     cache_pkl.parent.mkdir(parents=True, exist_ok=True)
     with cache_pkl.open("wb") as f:
-        pickle.dump({"graphify_raw": raw, "reafiner_data": data}, f)
+        pickle.dump({"graphify_raw": raw, "deeprefine_data": data}, f)
     return raw, data
 
 
@@ -204,4 +204,4 @@ def save_graphify_json(
 def save_bundle(cache_pkl: Path, raw: dict[str, Any], data: dict[str, Any]) -> None:
     cache_pkl.parent.mkdir(parents=True, exist_ok=True)
     with cache_pkl.open("wb") as f:
-        pickle.dump({"graphify_raw": raw, "reafiner_data": data}, f)
+        pickle.dump({"graphify_raw": raw, "deeprefine_data": data}, f)

--- a/deeprefine_skill/agent_loop.py
+++ b/deeprefine_skill/agent_loop.py
@@ -1,4 +1,4 @@
-"""Validate agent-native Reafiner loop traces (same control flow as Reafiner.refine())."""
+"""Validate agent-native refinement loop traces (same control flow as DeepRefine.refine())."""
 from __future__ import annotations
 
 import json
@@ -74,7 +74,7 @@ def format_interaction_history_for_abduction(
     *,
     horizon: int = HISTORY_HORIZON_DEFAULT,
 ) -> str:
-    """Same layout as Reafiner._error_abduction."""
+    """Same layout as DeepRefine._error_abduction."""
     rows = interaction_history[-horizon:]
     parts: list[str] = []
     for i, result in enumerate(rows):
@@ -89,7 +89,7 @@ def format_interaction_history_for_abduction(
 
 
 def reafiner_early_exit(interaction_history: list[dict[str, Any]]) -> bool:
-    """Reafiner.refine(): len(history) <= 1 → no KG refinement."""
+    """DeepRefine.refine(): len(history) <= 1 → no KG refinement."""
     return len(interaction_history) <= 1
 
 
@@ -99,7 +99,7 @@ def reafiner_needs_refinement(interaction_history: list[dict[str, Any]]) -> bool
 
 def validate_trace(trace: dict[str, Any], *, refinement_text: str | None = None) -> list[str]:
     """
-    Return human-readable errors. Empty list means the trace matches Reafiner control flow.
+    Return human-readable errors. Empty list means the trace matches DeepRefine control flow.
     """
     errors: list[str] = []
     if trace.get("schema_version") != 1:
@@ -181,7 +181,7 @@ def validate_trace(trace: dict[str, Any], *, refinement_text: str | None = None)
     early = reafiner_early_exit(ih)
     trace_early = trace.get("early_exit")
     if trace_early is not None and trace_early != early:
-        errors.append(f"early_exit={trace_early} but Reafiner rule gives {early}")
+        errors.append(f"early_exit={trace_early} but DeepRefine rule gives {early}")
 
     if early:
         if not last.get("answerable"):

--- a/deeprefine_skill/agent_prompts.py
+++ b/deeprefine_skill/agent_prompts.py
@@ -1,4 +1,4 @@
-"""DeepRefine Reafiner prompts — verbatim from autorefiner deeprefine_prompt.py."""
+"""DeepRefine refinement prompts — verbatim from autorefiner deeprefine_prompt.py."""
 
 REAFINER_JUDGEMENT_SYSTEM = """
 As an advanced judgement assistant, your task is to judge whether the given question is answerable based on the provided KG context.

--- a/deeprefine_skill/claude_skill/SKILL.md
+++ b/deeprefine_skill/claude_skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deeprefine
 description: >-
-  Claude Code adapter for the DeepRefine agent-native Reafiner loop. Use when
+  Claude Code adapter for the DeepRefine agent-native refinement loop. Use when
   the user invokes /deeprefine, or asks to refine, diagnose, review, or apply
   changes to a Graphify / LLM-Wiki knowledge graph. Must follow the canonical
   DeepRefine skill rules and stop for review before graph writes.
@@ -14,8 +14,8 @@ disable-model-invocation: false
 This file is the Claude Code-specific entrypoint. It keeps the platform rules
 small and loads longer DeepRefine procedure details only when needed:
 
-- Full workflow, queue selection, Reafiner branch logic, and review rules:
-  [references/reafiner-workflow.md](references/reafiner-workflow.md)
+- Full workflow, queue selection, refinement branch logic, and review rules:
+  [references/deeprefine-workflow.md](references/deeprefine-workflow.md)
 - Verbatim judgement, abduction, and refinement prompts:
   [references/llm-prompts.md](references/llm-prompts.md)
 - Checklist, command sequence, trace schema, paths, and CLI mode:
@@ -89,7 +89,7 @@ Use for `/deeprefine`, or requests to refine/improve/fix the graph.
 
 Follow the canonical reference in this order:
 
-1. `references/reafiner-workflow.md`
+1. `references/deeprefine-workflow.md`
 2. `references/llm-prompts.md` when producing tagged LLM outputs
 3. `references/trace-and-commands.md` when writing traces or running commands
 
@@ -117,7 +117,7 @@ reviewed refinement.
 
 Before applying, verify that the trace and refinement file match
 `references/trace-and-commands.md` and the review rules in
-`references/reafiner-workflow.md`. Then run:
+`references/deeprefine-workflow.md`. Then run:
 
 ```bash
 deeprefine loop validate --trace-file ... --refinement-file ...
@@ -157,8 +157,8 @@ If validation fails, fix the trace or rerun the missing step. Do not bypass with
 
 Keep this adapter concise. Load the smallest reference needed:
 
-- Full Reafiner pseudocode and safe review:
-  `references/reafiner-workflow.md`
+- Full refinement pseudocode and safe review:
+  `references/deeprefine-workflow.md`
 - Verbatim LLM prompts:
   `references/llm-prompts.md`
 - Required JSON shape, exact command sequence, and CLI/FAISS exception path:

--- a/deeprefine_skill/claude_skill/references/deeprefine-workflow.md
+++ b/deeprefine_skill/claude_skill/references/deeprefine-workflow.md
@@ -1,4 +1,4 @@
-# DeepRefine Reafiner Workflow
+# DeepRefine Agent Workflow
 
 Use this reference for the full `/deeprefine` workflow.
 
@@ -78,7 +78,7 @@ the latest query.
 
 ## Control Flow
 
-Follow the same branch structure as `Reafiner.refine()`.
+Follow the same branch structure as `DeepRefine.refine()`.
 
 ```text
 target_queries = pending_history_queries()

--- a/deeprefine_skill/claude_skill/references/llm-prompts.md
+++ b/deeprefine_skill/claude_skill/references/llm-prompts.md
@@ -52,7 +52,7 @@ User:
 Interaction history: {interaction_history}
 ```
 
-Format `interaction_history` like Reafiner:
+Format `interaction_history` like DeepRefine:
 
 ```text
 Step1:

--- a/deeprefine_skill/claude_skill/references/trace-and-commands.md
+++ b/deeprefine_skill/claude_skill/references/trace-and-commands.md
@@ -13,7 +13,7 @@ Report these items in chat for each query:
 [ ] Step 1: graphify query executed (evidence in trace)
 [ ] Each step: <judge>Yes|No</judge> shown in chat
 [ ] Hops stopped on Yes OR reached MAX_HOPS
-[ ] early_exit OR (abduction + refinement) per Reafiner branch
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
 [ ] deeprefine loop validate passed
 [ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
 [ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message

--- a/deeprefine_skill/cli.py
+++ b/deeprefine_skill/cli.py
@@ -324,11 +324,11 @@ def cmd_index(args: argparse.Namespace) -> int:
     del llm
     load_or_build_data(
         paths["graph_json"],
-        paths["reafiner_pkl"],
+        paths["deeprefine_pkl"],
         encoder,
         rebuild=True,
     )
-    print(f"Index cache: {paths['reafiner_pkl']}")
+    print(f"Index cache: {paths['deeprefine_pkl']}")
     return 0
 
 
@@ -369,7 +369,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
         errs = validate_trace(trace, refinement_text=text)
         if errs:
             print(
-                "Loop trace validation failed (must match Reafiner.refine()):",
+                "Loop trace validation failed (must match DeepRefine.refine()):",
                 file=sys.stderr,
             )
             for e in errs:
@@ -480,11 +480,11 @@ def cmd_loop_validate(args: argparse.Namespace) -> int:
             refinement_text = Path(ref).read_text(encoding="utf-8")
     errs = validate_trace(load_trace(trace_path), refinement_text=refinement_text)
     if errs:
-        print("INVALID — does not match Reafiner.refine() control flow:")
+        print("INVALID — does not match DeepRefine.refine() control flow:")
         for e in errs:
             print(f"  - {e}")
         return 1
-    print("OK — loop trace matches Reafiner.refine() rules.")
+    print("OK — loop trace matches DeepRefine.refine() rules.")
     return 0
 
 
@@ -901,7 +901,7 @@ def main(argv: list[str] | None = None) -> int:
     p_apply.add_argument(
         "--trace-file",
         required=False,
-        help="loop_trace_<id>.json — validated against Reafiner.refine() before apply",
+        help="loop_trace_<id>.json — validated against DeepRefine.refine() before apply",
     )
     p_apply.add_argument(
         "--skip-trace-check",
@@ -916,14 +916,14 @@ def main(argv: list[str] | None = None) -> int:
     p_apply.add_argument("--project-root", default=None)
     p_apply.set_defaults(func=cmd_apply)
 
-    p_loop = sub.add_parser("loop", help="Agent Reafiner loop trace (no FAISS)")
+    p_loop = sub.add_parser("loop", help="Agent refinement loop trace (no FAISS)")
     loop_sub = p_loop.add_subparsers(dest="loop_cmd", required=True)
     p_li = loop_sub.add_parser("init", help="Create loop_trace_<id>.json template")
     p_li.add_argument("--query", required=True)
     p_li.add_argument("--trace-file", default=None)
     p_li.set_defaults(func=cmd_loop_init)
     p_lv = loop_sub.add_parser(
-        "validate", help="Check trace matches Reafiner control flow"
+        "validate", help="Check trace matches DeepRefine control flow"
     )
     p_lv.add_argument("--trace-file", required=True)
     p_lv.add_argument("--refinement-file", default=None)

--- a/deeprefine_skill/codex_skill/SKILL.md
+++ b/deeprefine_skill/codex_skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deeprefine
 description: >-
-  Codex adapter for the DeepRefine agent-native Reafiner loop. Use when the
+  Codex adapter for the DeepRefine agent-native refinement loop. Use when the
   user invokes $deeprefine or /deeprefine, or asks to refine, diagnose, review,
   or apply changes to a Graphify / LLM-Wiki knowledge graph. Must follow the
   canonical DeepRefine skill rules and stop for review before graph writes.
@@ -12,8 +12,8 @@ description: >-
 This file is the Codex-specific entrypoint. It keeps the platform rules small
 and loads longer DeepRefine procedure details only when needed:
 
-- Full workflow, queue selection, Reafiner branch logic, and review rules:
-  [references/reafiner-workflow.md](references/reafiner-workflow.md)
+- Full workflow, queue selection, refinement branch logic, and review rules:
+  [references/deeprefine-workflow.md](references/deeprefine-workflow.md)
 - Verbatim judgement, abduction, and refinement prompts:
   [references/llm-prompts.md](references/llm-prompts.md)
 - Checklist, command sequence, trace schema, paths, and CLI mode:
@@ -88,7 +88,7 @@ graph.
 
 Follow the canonical reference in this order:
 
-1. `references/reafiner-workflow.md`
+1. `references/deeprefine-workflow.md`
 2. `references/llm-prompts.md` when producing tagged LLM outputs
 3. `references/trace-and-commands.md` when writing traces or running commands
 
@@ -116,7 +116,7 @@ reviewed refinement.
 
 Before applying, verify that the trace and refinement file match
 `references/trace-and-commands.md` and the review rules in
-`references/reafiner-workflow.md`. Then run:
+`references/deeprefine-workflow.md`. Then run:
 
 ```bash
 deeprefine loop validate --trace-file ... --refinement-file ...
@@ -156,8 +156,8 @@ If validation fails, fix the trace or rerun the missing step. Do not bypass with
 
 Keep this adapter concise. Load the smallest reference needed:
 
-- Full Reafiner pseudocode and safe review:
-  `references/reafiner-workflow.md`
+- Full refinement pseudocode and safe review:
+  `references/deeprefine-workflow.md`
 - Verbatim LLM prompts:
   `references/llm-prompts.md`
 - Required JSON shape, exact command sequence, and CLI/FAISS exception path:

--- a/deeprefine_skill/codex_skill/references/deeprefine-workflow.md
+++ b/deeprefine_skill/codex_skill/references/deeprefine-workflow.md
@@ -1,4 +1,4 @@
-# DeepRefine Reafiner Workflow
+# DeepRefine Agent Workflow
 
 Use this reference for the full `$deeprefine` / `/deeprefine` workflow.
 
@@ -78,7 +78,7 @@ the latest query.
 
 ## Control Flow
 
-Follow the same branch structure as `Reafiner.refine()`.
+Follow the same branch structure as `DeepRefine.refine()`.
 
 ```text
 target_queries = pending_history_queries()

--- a/deeprefine_skill/codex_skill/references/llm-prompts.md
+++ b/deeprefine_skill/codex_skill/references/llm-prompts.md
@@ -52,7 +52,7 @@ User:
 Interaction history: {interaction_history}
 ```
 
-Format `interaction_history` like Reafiner:
+Format `interaction_history` like DeepRefine:
 
 ```text
 Step1:

--- a/deeprefine_skill/codex_skill/references/trace-and-commands.md
+++ b/deeprefine_skill/codex_skill/references/trace-and-commands.md
@@ -13,7 +13,7 @@ Report these items in chat for each query:
 [ ] Step 1: graphify query executed (evidence in trace)
 [ ] Each step: <judge>Yes|No</judge> shown in chat
 [ ] Hops stopped on Yes OR reached MAX_HOPS
-[ ] early_exit OR (abduction + refinement) per Reafiner branch
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
 [ ] deeprefine loop validate passed
 [ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
 [ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message

--- a/deeprefine_skill/gemini_extension/GEMINI.md
+++ b/deeprefine_skill/gemini_extension/GEMINI.md
@@ -7,7 +7,7 @@ Use the `deeprefine` skill when the user asks to refine, diagnose, debug, improv
 ## Core behavior
 
 1. Prefer the agent-native DeepRefine loop over the terminal-only `deeprefine refine` command unless the user explicitly requests CLI / FAISS mode.
-2. Follow the same control flow as `Reafiner.refine()` from DeepRefine.
+2. Follow the same control flow as `DeepRefine.refine()` from DeepRefine.
 3. Import Graphify memory with `deeprefine history sync-memory` when running the default queue workflow.
 4. Process pending history entries one by one.
 5. Use Graphify query results and k-hop expansion over `graphify-out/graph.json` as retrieval evidence.

--- a/deeprefine_skill/gemini_extension/skills/deeprefine/SKILL.md
+++ b/deeprefine_skill/gemini_extension/skills/deeprefine/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: deeprefine
 description: >-
-  Agent-native DeepRefine Reafiner loop — same control flow as Reafiner.refine(),
+  Agent-native DeepRefine refinement loop — same control flow as DeepRefine.refine(),
   graphify search instead of FAISS, session LLM, dry-run review before approved graph writes.
 disable-model-invocation: false
 ---
 
-# DeepRefine — Agent Reafiner loop (strict)
+# DeepRefine — Agent refinement loop (strict)
 
 ## Default safety policy: dry-run only
 
@@ -31,7 +31,7 @@ Do not treat generation of `<refinement>` actions as approval. Do not treat a va
 
 ---
 
-You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
+You **MUST** implement the **same control flow** as `DeepRefine.refine()` in DeepRefine (`autorefiner/src/deeprefine.py`).
 
 | Component | Agent mode | CLI `deeprefine refine` |
 |-----------|------------|-------------------------|
@@ -60,7 +60,7 @@ If validation fails, **fix the trace and re-run the missing step** — do not by
 
 ---
 
-## Constants (match `refine_runner.py` / Reafiner)
+## Constants (match `refine_runner.py` / DeepRefine)
 
 ```text
 MAX_HOPS = 4
@@ -103,12 +103,12 @@ Run `deeprefine loop validate --trace-file ...` after abduction and before `revi
    - preserve file order
 3. If pending queue is non-empty: set `target_queries = pending_queue`.
 4. If pending queue is empty: set `target_queries = [current session question]`.
-5. Run the full Reafiner loop for **each** query in `target_queries`, one by one.
+5. Run the full refinement loop for **each** query in `target_queries`, one by one.
 6. For early-exit queries, finish immediately. For refinement-path queries, generate review output and wait for user approval before `apply` + `loop finish`.
 
 ---
 
-## Control flow (must match `Reafiner.refine()`)
+## Control flow (must match `DeepRefine.refine()`)
 
 Pseudocode — follow **exactly**:
 
@@ -150,7 +150,7 @@ for question in target_queries:
         if answerable:
             BREAK   # stop hop loop
 
-    # --- same branch as Reafiner.refine() line 314+ ---
+    # --- same branch as DeepRefine.refine() line 314+ ---
     if len(interaction_history) <= 1:
         # Early exit: first hop was answerable — NO graph refinement
         set trace.early_exit = true
@@ -186,7 +186,7 @@ for question in target_queries:
             deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
-**Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+**Critical refinement rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
 
 **Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
 
@@ -255,7 +255,7 @@ Analyze the reasons of the unanswerable questions based on the given interaction
 Interaction history: {interaction_history}
 ```
 
-`{interaction_history}` format (same as Reafiner):
+`{interaction_history}` format (same as DeepRefine):
 
 ```text
 Step1:
@@ -307,7 +307,7 @@ Copy and tick each item in your final message:
 [ ] Step 1: graphify query executed (evidence in trace)
 [ ] Each step: <judge>Yes|No</judge> shown in chat
 [ ] Hops stopped on Yes OR reached MAX_HOPS
-[ ] early_exit OR (abduction + refinement) per Reafiner branch
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
 [ ] deeprefine loop validate passed
 [ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
 [ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message

--- a/deeprefine_skill/installers.py
+++ b/deeprefine_skill/installers.py
@@ -308,7 +308,7 @@ def uninstall_codex_skill(*, project: bool) -> bool:
     for dest in [
         dest_dir / _SKILL_MD_NAME,
         dest_dir / "agents" / _OPENAI_YAML_NAME,
-        dest_dir / _CODEX_REFERENCES_DIR / "reafiner-workflow.md",
+        dest_dir / _CODEX_REFERENCES_DIR / "deeprefine-workflow.md",
         dest_dir / _CODEX_REFERENCES_DIR / "llm-prompts.md",
         dest_dir / _CODEX_REFERENCES_DIR / "trace-and-commands.md",
         dest_dir / _CODEX_REFERENCES_DIR / _LEGACY_CODEX_AGENT_LOOP_REF_NAME,
@@ -374,7 +374,7 @@ def uninstall_claude_skill(*, project: bool) -> bool:
     removed = False
     for dest in [
         dest_dir / _SKILL_MD_NAME,
-        dest_dir / _CLAUDE_REFERENCES_DIR / "reafiner-workflow.md",
+        dest_dir / _CLAUDE_REFERENCES_DIR / "deeprefine-workflow.md",
         dest_dir / _CLAUDE_REFERENCES_DIR / "llm-prompts.md",
         dest_dir / _CLAUDE_REFERENCES_DIR / "trace-and-commands.md",
     ]:

--- a/deeprefine_skill/paths.py
+++ b/deeprefine_skill/paths.py
@@ -61,7 +61,7 @@ def graphify_paths(project_root: Path) -> dict[str, Path]:
         "graph_json": out / "graph.json",
         "history": deep / "history.jsonl",
         "cache_dir": deep / "cache",
-        "reafiner_pkl": deep / "cache" / "reafiner_data.pkl",
+        "deeprefine_pkl": deep / "cache" / "deeprefine_data.pkl",
         "graph_backup": deep / "graph.json.bak",
     }
 

--- a/deeprefine_skill/refine_runner.py
+++ b/deeprefine_skill/refine_runner.py
@@ -9,7 +9,7 @@ from openai import OpenAI
 
 from atlas_rag.llm_generator import GenerationConfig, LLMGenerator
 from atlas_rag.vectorstore.embedding_model import Qwen3Emb
-from autorefiner.src.reafiner import Reafiner, RetrievalStepResult
+from autorefiner.src.deeprefine import DeepRefine, RetrievalStepResult
 
 from .adapter_graphify import (
     load_or_build_data,
@@ -117,7 +117,7 @@ def run_refine(
     )
     original_kg = data["KG"].copy()
 
-    reafiner = Reafiner(
+    deeprefine = DeepRefine(
         data=data,
         sentence_encoder=encoder,
         llm_generator=llm,
@@ -140,9 +140,9 @@ def run_refine(
             return
         if not apply:
             return
-        data["KG"] = reafiner.kg
+        data["KG"] = deeprefine.kg
         nonlocal raw
-        raw = sync_kg_to_graphify(raw, reafiner.kg)
+        raw = sync_kg_to_graphify(raw, deeprefine.kg)
         save_graphify_json(graph_path, raw, backup_path=backup_path)
         save_bundle(cache_pkl, raw, data)
         mark_refined(history_path, refined_ids)
@@ -153,7 +153,7 @@ def run_refine(
                 query = sample["query"]
                 qid = query_id(query, sample.get("id"))
                 print(f"\n=== [{qid}] {query}")
-                final_answer, _, refinement_result = reafiner.refine(query=query)
+                final_answer, _, refinement_result = deeprefine.refine(query=query)
                 record = refinement_to_jsonable(sample, final_answer, refinement_result)
                 log_f.write(json.dumps(record, ensure_ascii=False) + "\n")
                 log_f.flush()
@@ -192,8 +192,8 @@ def run_refine(
                     summary_rows[-1]["review_file"] = str(review_file)
                     summary_rows[-1]["mode"] = "apply" if apply else "dry-run"
                 print(
-                    f"  steps={n_steps}, nodes={reafiner.kg.number_of_nodes()}, "
-                    f"edges={reafiner.kg.number_of_edges()}"
+                    f"  steps={n_steps}, nodes={deeprefine.kg.number_of_nodes()}, "
+                    f"edges={deeprefine.kg.number_of_edges()}"
                 )
                 if action_file and review_file:
                     print(
@@ -202,15 +202,15 @@ def run_refine(
                     )
                 if not apply:
                     data["KG"] = original_kg.copy()
-                    reafiner.kg = data["KG"]
+                    deeprefine.kg = data["KG"]
     finally:
         _persist()
 
     return {
         "log_path": str(log_path),
         "graph_path": str(graph_path),
-        "nodes": reafiner.kg.number_of_nodes(),
-        "edges": reafiner.kg.number_of_edges(),
+        "nodes": deeprefine.kg.number_of_nodes(),
+        "edges": deeprefine.kg.number_of_edges(),
         "queries_processed": len(queries),
         "mode": "apply" if apply else "dry-run",
         "summary": summary_rows,
@@ -241,7 +241,7 @@ def refine_from_history(
 
     return run_refine(
         graph_path=paths["graph_json"],
-        cache_pkl=paths["reafiner_pkl"],
+        cache_pkl=paths["deeprefine_pkl"],
         backup_path=paths["graph_backup"],
         history_path=paths["history"],
         log_dir=paths["graphify_out"] / ".deeprefine",

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -18,7 +18,7 @@ This installs:
 .agents/skills/deeprefine/
 |-- SKILL.md
 |-- references/
-|   |-- reafiner-workflow.md
+|   |-- deeprefine-workflow.md
 |   |-- llm-prompts.md
 |   `-- trace-and-commands.md
 `-- agents/
@@ -37,7 +37,7 @@ User-wide installation writes to:
 ~/.codex/skills/deeprefine/
 |-- SKILL.md
 |-- references/
-|   |-- reafiner-workflow.md
+|   |-- deeprefine-workflow.md
 |   |-- llm-prompts.md
 |   `-- trace-and-commands.md
 `-- agents/
@@ -65,7 +65,7 @@ The Codex skill:
 
 1. Runs `deeprefine history sync-memory`.
 2. Processes pending query history from `graphify-out/.deeprefine/history.jsonl`.
-3. Uses Graphify retrieval and the session model for the Reafiner loop.
+3. Uses Graphify retrieval and the session model for the refinement loop.
 4. Generates proposed `<refinement>` actions when refinement is needed.
 5. Runs `deeprefine loop validate` and `deeprefine review`.
 6. Stops before graph writes and asks for explicit approval.

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -45,7 +45,7 @@ Instead, the skill uses keyword-based mode detection from the user's message:
 
 | Mode | Trigger keywords | Behaviour |
 |------|-----------------|-----------|
-| **Full workflow** | `/deeprefine`, "refine", "improve", "fix", "diagnose" | Full Reafiner loop for all pending queries; stops after dry-run review; asks for explicit approval before writing `graph.json` |
+| **Full workflow** | `/deeprefine`, "refine", "improve", "fix", "diagnose" | Full refinement loop for all pending queries; stops after dry-run review; asks for explicit approval before writing `graph.json` |
 | **Review only** | "review", "check", "audit", "inspect", "dry-run", "what would change" | Reads trace and refinement files; shows HIGH/MEDIUM/LOW evidence report; does not modify any files |
 | **Apply only** | "approve", "apply", "write", "go ahead", "proceed", "yes apply" | Runs `deeprefine apply` only after a prior review; requires explicit user approval in the current message |
 

--- a/skills/deeprefine/SKILL.md
+++ b/skills/deeprefine/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: deeprefine
 description: >-
-  Agent-native DeepRefine Reafiner loop — same control flow as Reafiner.refine(),
+  Agent-native DeepRefine refinement loop — same control flow as DeepRefine.refine(),
   graphify search instead of FAISS, session LLM, dry-run review before approved graph writes.
 disable-model-invocation: false
 ---
 
-# DeepRefine — Agent Reafiner loop (strict)
+# DeepRefine — Agent refinement loop (strict)
 
 ## Default safety policy: dry-run only
 
@@ -31,7 +31,7 @@ Do not treat generation of `<refinement>` actions as approval. Do not treat a va
 
 ---
 
-You **MUST** implement the **same control flow** as `Reafiner.refine()` in DeepRefine (`autorefiner/src/reafiner.py`).
+You **MUST** implement the **same control flow** as `DeepRefine.refine()` in DeepRefine (`autorefiner/src/deeprefine.py`).
 
 | Component | Agent mode | CLI `deeprefine refine` |
 |-----------|------------|-------------------------|
@@ -60,7 +60,7 @@ If validation fails, **fix the trace and re-run the missing step** — do not by
 
 ---
 
-## Constants (match `refine_runner.py` / Reafiner)
+## Constants (match `refine_runner.py` / DeepRefine)
 
 ```text
 MAX_HOPS = 4
@@ -103,12 +103,12 @@ Run `deeprefine loop validate --trace-file ...` after abduction and before `revi
    - preserve file order
 3. If pending queue is non-empty: set `target_queries = pending_queue`.
 4. If pending queue is empty: set `target_queries = [current session question]`.
-5. Run the full Reafiner loop for **each** query in `target_queries`, one by one.
+5. Run the full refinement loop for **each** query in `target_queries`, one by one.
 6. For early-exit queries, finish immediately. For refinement-path queries, generate review output and wait for user approval before `apply` + `loop finish`.
 
 ---
 
-## Control flow (must match `Reafiner.refine()`)
+## Control flow (must match `DeepRefine.refine()`)
 
 Pseudocode — follow **exactly**:
 
@@ -150,7 +150,7 @@ for question in target_queries:
         if answerable:
             BREAK   # stop hop loop
 
-    # --- same branch as Reafiner.refine() line 314+ ---
+    # --- same branch as DeepRefine.refine() line 314+ ---
     if len(interaction_history) <= 1:
         # Early exit: first hop was answerable — NO graph refinement
         set trace.early_exit = true
@@ -186,7 +186,7 @@ for question in target_queries:
             deeprefine loop finish --trace-file ... --refinement-file ...
 ```
 
-**Critical Reafiner rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
+**Critical refinement rule:** refinement runs when `len(interaction_history) > 1`, not only when all judgements are `No`.
 
 **Safe-review rule:** a refinement path is dry-run by default. Generating `<refinement>` actions is not approval to write `graph.json`, and a normal `/deeprefine` turn must end after `deeprefine review`.
 
@@ -255,7 +255,7 @@ Analyze the reasons of the unanswerable questions based on the given interaction
 Interaction history: {interaction_history}
 ```
 
-`{interaction_history}` format (same as Reafiner):
+`{interaction_history}` format (same as DeepRefine):
 
 ```text
 Step1:
@@ -307,7 +307,7 @@ Copy and tick each item in your final message:
 [ ] Step 1: graphify query executed (evidence in trace)
 [ ] Each step: <judge>Yes|No</judge> shown in chat
 [ ] Hops stopped on Yes OR reached MAX_HOPS
-[ ] early_exit OR (abduction + refinement) per Reafiner branch
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
 [ ] deeprefine loop validate passed
 [ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
 [ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message


### PR DESCRIPTION
Upstream commits b7323ce and 3721de3 renamed:
- autorefiner/src/reafiner.py → deeprefine.py
- class Reafiner → DeepRefine

Changes:
- fix: refine_runner.py import (would ModuleNotFoundError)
- rename: build_reafiner_data → build_deeprefine_data
- rename: reafiner_pkl → deeprefine_pkl (cache key)
- rename: reafiner-workflow.md → deeprefine-workflow.md
- docs: update all SKILL.md and README references