### PR TITLE
feat: add DeepSeek Harness (dsh) skill adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ build/
 # Personal working documents — kept locally, not distributed
 docs/tmp/
 .github/skills/
+.dsh/
 .omo/
 graphify-out/
 venv/ 
+eval/data/
+eval/results/

--- a/deeprefine_skill/action_review.py
+++ b/deeprefine_skill/action_review.py
@@ -330,7 +330,7 @@ def render_review_markdown(reviews: list[ActionReview]) -> str:
             lines.append("Suggested replacement:")
             lines.append(f"- {review.suggested_replacement}")
         lines.append("")
-    lines.append("Apply only after review: deeprefine apply --refresh-wiki --trace-file <trace> --refinement-file <actions>")
+    lines.append("Apply only after review: deeprefine apply --trace-file <trace> --refinement-file <actions>")
     return "\n".join(lines).rstrip() + "\n"
 
 

--- a/deeprefine_skill/cli.py
+++ b/deeprefine_skill/cli.py
@@ -1,10 +1,10 @@
 """DeepRefine CLI — command-line entry point for the DeepRefine agent skill.
 
 Provides subcommands for platform-specific skill installation (Cursor,
-Copilot CLI, Gemini CLI, Codex, OpenCode), query-history management,
-FAISS index rebuilding, dry-run refinement review, graph refinement,
-loop-trace lifecycle management, and applying refinement actions to
-``graph.json``.
+Copilot CLI, Gemini CLI, Codex, OpenCode, DeepSeek Harness), query-history
+management, FAISS index rebuilding, dry-run refinement review, graph
+refinement, loop-trace lifecycle management, and applying refinement actions
+to ``graph.json``.
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ from deeprefine_skill.installers import (
     install_codex_skill,
     install_copilot_skill,
     install_cursor_skill,
+    install_dsh_skill,
     install_gemini_extension,
     install_opencode_skill,
     link_gemini_extension,
@@ -35,6 +36,7 @@ from deeprefine_skill.installers import (
     uninstall_codex_skill,
     uninstall_copilot_skill,
     uninstall_cursor_skill,
+    uninstall_dsh_skill,
     uninstall_gemini_extension,
     uninstall_opencode_skill,
 )
@@ -186,6 +188,32 @@ def cmd_opencode_uninstall(args: argparse.Namespace) -> int:
     if removed:
         scope = "project" if args.project else "user"
         print(f"Removed DeepRefine OpenCode skill and commands ({scope}).")
+    else:
+        print("Skill not installed at the selected scope.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek Harness (dsh) handlers
+# ---------------------------------------------------------------------------
+
+
+def cmd_dsh_install(args: argparse.Namespace) -> int:
+    """``deeprefine dsh install`` - install SKILL.md for DeepSeek Harness."""
+    dest = install_dsh_skill(project=args.project)
+    scope = "project" if args.project else "user"
+    print(f"Installed DeepRefine dsh skill ({scope}) -> {dest}")
+    if args.project:
+        print("Restart dsh, then invoke /deeprefine.")
+    return 0
+
+
+def cmd_dsh_uninstall(args: argparse.Namespace) -> int:
+    """``deeprefine dsh uninstall`` - remove the dsh skill."""
+    removed = uninstall_dsh_skill(project=args.project)
+    if removed:
+        scope = "project" if args.project else "user"
+        print(f"Removed DeepRefine dsh skill ({scope}).")
     else:
         print("Skill not installed at the selected scope.")
     return 0
@@ -791,6 +819,34 @@ def main(argv: list[str] | None = None) -> int:
         user_help="Remove from ~/.opencode/skills/deeprefine (all projects)",
     )
     p_opu.set_defaults(func=cmd_opencode_uninstall, _default_project=True)
+
+    # deeprefine dsh install | uninstall
+    p_dsh = sub.add_parser("dsh", help="DeepSeek Harness skill integration")
+    dsh_sub = p_dsh.add_subparsers(dest="dsh_cmd", required=True)
+
+    p_di = dsh_sub.add_parser(
+        "install", help="Install /deeprefine skill for DeepSeek Harness"
+    )
+    _add_project_flag(
+        p_di,
+        project_help=(
+            "Install to .dsh/skills/deeprefine in the current directory "
+            "(default for dsh install)"
+        ),
+        user_help="Install to ~/.dsh/skills/deeprefine (all projects)",
+    )
+    p_di.set_defaults(func=cmd_dsh_install, _default_project=True)
+
+    p_du = dsh_sub.add_parser("uninstall", help="Remove dsh skill")
+    _add_project_flag(
+        p_du,
+        project_help=(
+            "Remove from .dsh/skills/deeprefine in the current directory "
+            "(default for dsh uninstall)"
+        ),
+        user_help="Remove from ~/.dsh/skills/deeprefine (all projects)",
+    )
+    p_du.set_defaults(func=cmd_dsh_uninstall, _default_project=True)
 
     # deeprefine gemini link | install | uninstall | path
     p_gemini = sub.add_parser("gemini", help="Gemini CLI integration")

--- a/deeprefine_skill/dsh_skill/SKILL.md
+++ b/deeprefine_skill/dsh_skill/SKILL.md
@@ -77,8 +77,9 @@ Do not treat any of these as approval:
 - a prior user message;
 - a successful `deeprefine review`.
 
-If the review contains LOW-confidence actions, use
-`--allow-low-confidence` only when the user's current approval message
+If the review contains any LOW-confidence action, `deeprefine apply` aborts and
+writes nothing (it does NOT apply HIGH/MEDIUM actions while skipping LOW ones).
+Use `--allow-low-confidence` only when the user's current approval message
 explicitly accepts that risk.
 
 ## Mode Selection
@@ -131,6 +132,23 @@ same user message:
 ```bash
 deeprefine apply --allow-low-confidence --trace-file ... --refinement-file ...
 ```
+
+### After review: closing options
+
+After showing the HIGH/MEDIUM/LOW report, stop and present these options to the
+user instead of deciding on your own:
+
+- **Approve & apply** — the user explicitly says approve/apply/write. Run
+  `deeprefine apply` (it aborts if any LOW action is present unless
+  `--allow-low-confidence` is given) then `deeprefine loop finish`.
+- **Skip apply, mark done** — the user declines the changes. Run
+  `deeprefine loop finish --trace-file ... --refinement-file ...` with no graph
+  write.
+- **Leave as proposal** — the user wants to stop. Do not finish; leave the
+  trace and review as-is for later.
+
+Never run `deeprefine apply` before the user's current message explicitly
+approves it, regardless of which option they later pick.
 
 ## Non-Negotiable Rules
 

--- a/deeprefine_skill/dsh_skill/SKILL.md
+++ b/deeprefine_skill/dsh_skill/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: deeprefine
+description: >-
+  DeepSeek Harness (dsh) adapter for the DeepRefine agent-native refinement
+  loop. Use when the user invokes /deeprefine, or asks to refine, diagnose,
+  review, or apply changes to a Graphify / LLM-Wiki knowledge graph. Must
+  follow the canonical DeepRefine skill rules and stop for review before
+  graph writes.
+disable-model-invocation: false
+---
+
+# DeepRefine - DeepSeek Harness (dsh) Adapter
+
+This file is the dsh-specific entrypoint. It keeps the platform rules small
+and loads longer DeepRefine procedure details only when needed:
+
+- Full workflow, queue selection, refinement branch logic, and review rules:
+  [references/deeprefine-workflow.md](references/deeprefine-workflow.md)
+- Verbatim judgement, abduction, and refinement prompts:
+  [references/llm-prompts.md](references/llm-prompts.md)
+- Checklist, command sequence, trace schema, paths, and CLI mode:
+  [references/trace-and-commands.md](references/trace-and-commands.md)
+
+Do not reimplement or shorten the algorithm from memory. Load the relevant
+reference file before executing that part of the workflow.
+
+## dsh Invocation
+
+Trigger this skill when the user:
+
+- explicitly invokes `/deeprefine`;
+- asks to refine, improve, diagnose, repair, inspect, or review a Graphify
+  knowledge graph;
+- asks to apply a previously reviewed DeepRefine refinement.
+
+Run from the knowledge-base project root, where `graphify-out/graph.json`
+exists. If the user is planning or asking how DeepRefine works, explain the
+workflow and do not mutate files.
+
+If `deeprefine` is unavailable, tell the user to install it:
+
+```bash
+pip install deeprefine-cli
+```
+
+For source development:
+
+```bash
+pip install -e /path/to/DeepRefine-Skill
+```
+
+## Hard Safety Policy
+
+A normal `/deeprefine` invocation is dry-run only and **MUST NEVER** call
+`deeprefine apply`.
+
+The default workflow must stop after:
+
+1. `deeprefine loop validate`
+2. `deeprefine review`
+3. showing the proposed actions and HIGH/MEDIUM/LOW review report to the user
+
+Then ask for explicit approval.
+
+Only if the user's next message explicitly says to approve/apply/write the graph
+may you run:
+
+```bash
+deeprefine apply --trace-file ... --refinement-file ...
+deeprefine loop finish --trace-file ... --refinement-file ...
+```
+
+Do not treat any of these as approval:
+
+- generation of a `<refinement>` block;
+- a valid `loop_trace_<query_id>.json`;
+- a prior user message;
+- a successful `deeprefine review`.
+
+If the review contains LOW-confidence actions, use
+`--allow-low-confidence` only when the user's current approval message
+explicitly accepts that risk.
+
+## Mode Selection
+
+### Full workflow
+
+Use for `/deeprefine`, or requests to refine/improve/fix the graph.
+
+Follow the canonical reference in this order:
+
+1. `references/deeprefine-workflow.md`
+2. `references/llm-prompts.md` when producing tagged LLM outputs
+3. `references/trace-and-commands.md` when writing traces or running commands
+
+Do not copy only the latest query if pending history exists. Process all
+unrefined history queries first, preserving canonical dedupe/order rules.
+
+### Review only
+
+Use when the user asks to review, audit, inspect, dry-run, check evidence, or
+show what would change.
+
+Run validation and review only:
+
+```bash
+deeprefine loop validate --trace-file ... --refinement-file ...
+deeprefine review --trace-file ... --refinement-file ...
+```
+
+Show the HIGH/MEDIUM/LOW evidence report. Do not modify `graph.json`.
+
+### Apply only
+
+Use only when the user's current message explicitly approves a previously
+reviewed refinement.
+
+Before applying, verify that the trace and refinement file match
+`references/trace-and-commands.md` and the review rules in
+`references/deeprefine-workflow.md`. Then run:
+
+```bash
+deeprefine loop validate --trace-file ... --refinement-file ...
+deeprefine apply --trace-file ... --refinement-file ...
+deeprefine loop finish --trace-file ... --refinement-file ...
+```
+
+Use the LOW-confidence override only with explicit risk acknowledgement in the
+same user message:
+
+```bash
+deeprefine apply --allow-low-confidence --trace-file ... --refinement-file ...
+```
+
+## Non-Negotiable Rules
+
+These are restated here so the model always sees the hard stops before loading
+any reference.
+
+Do not:
+
+1. Run `deeprefine refine` unless the user explicitly asks for CLI/FAISS mode.
+2. Call `deeprefine apply` without a valid `loop_trace_<query_id>.json`.
+3. Call `deeprefine apply` before `deeprefine review` and explicit approval.
+4. Ignore LOW-confidence review warnings without explicit risk acceptance.
+5. Skip any hop's `<judge>Yes</judge>` / `<judge>No</judge>` judgement.
+6. Skip error abduction when `len(interaction_history) > 1`.
+7. Write `<refinement>` before abduction when refinement is required.
+8. Hand-edit `graphify-out/graph.json` with Python or ad-hoc JSON patches.
+9. Ignore pending history and refine only one latest query.
+10. Invent a shorter pipeline such as "read file -> write refinement -> apply".
+
+If validation fails, fix the trace or rerun the missing step. Do not bypass with
+`--skip-trace-check` in agent mode.
+
+## What to Load From References
+
+Keep this adapter concise. Load the smallest reference needed:
+
+- Full refinement pseudocode and safe review:
+  `references/deeprefine-workflow.md`
+- Verbatim LLM prompts:
+  `references/llm-prompts.md`
+- Required JSON shape, exact command sequence, and CLI/FAISS exception path:
+  `references/trace-and-commands.md`
+
+Use the canonical commands and artifacts exactly as written there. This adapter
+only maps those rules onto dsh's `/deeprefine` invocation and approval
+behavior.

--- a/deeprefine_skill/dsh_skill/references/deeprefine-workflow.md
+++ b/deeprefine_skill/dsh_skill/references/deeprefine-workflow.md
@@ -1,0 +1,159 @@
+# DeepRefine Agent Workflow
+
+Use this reference for the full `/deeprefine` workflow.
+
+## Safety Policy
+
+A normal `/deeprefine` invocation must stop after:
+
+1. `deeprefine loop validate`
+2. `deeprefine review`
+3. showing the proposed actions and HIGH/MEDIUM/LOW review report
+
+Then ask the user for explicit approval. Do not run `deeprefine apply` in the
+same default refinement turn.
+
+Approval must be in the user's current message and must explicitly say to
+approve/apply/write the graph. A generated `<refinement>` block, a valid trace,
+or a successful review is not approval.
+
+## Forbidden
+
+Do not:
+
+1. Run `deeprefine refine` unless the user explicitly asks for CLI/FAISS mode.
+2. Call `deeprefine apply` without a valid `loop_trace_<query_id>.json`.
+3. Call `deeprefine apply` before `deeprefine review` and explicit approval.
+4. Ignore LOW-confidence warnings unless the user explicitly accepts the risk.
+5. Skip any hop's `<judge>Yes</judge>` / `<judge>No</judge>` judgement.
+6. Skip error abduction when `len(interaction_history) > 1`.
+7. Write `<refinement>` before abduction when refinement is required.
+8. Hand-edit `graphify-out/graph.json` with Python or ad-hoc JSON patches.
+9. Ignore pending history and refine only one latest query.
+10. Invent a shorter pipeline such as "read file -> write refinement -> apply".
+
+If validation fails, fix the trace or rerun the missing step. Do not bypass with
+`--skip-trace-check` in agent mode.
+
+## Constants
+
+```text
+MAX_HOPS = 4
+INCREMENT_HOP = 1
+BASE_TOP_K = 10
+MAX_TRIPLE_NUM_BY_STEP = [5, 10, 15, 20]
+HISTORY_HORIZON = 4
+```
+
+## Mandatory Artifact
+
+For each query, maintain:
+
+```text
+graphify-out/.deeprefine/loop_trace_<query_id>.json
+```
+
+Create the template with:
+
+```bash
+deeprefine loop init --query "<exact question>"
+```
+
+Append each hop to `interaction_history` before starting the next hop. Run
+`deeprefine loop validate --trace-file ...` after abduction and before review or
+approved apply.
+
+## Query Queue Selection
+
+Default `/deeprefine` must process all unrefined history queries first, not only
+the latest query.
+
+1. Run `deeprefine history sync-memory`.
+2. Read `graphify-out/.deeprefine/history.jsonl`.
+3. Include rows where `refined != true`.
+4. Dedupe by `id`, preserving first occurrence and file order.
+5. If the pending queue is non-empty, use it as `target_queries`.
+6. If the queue is empty, use the current session question.
+7. Process target queries sequentially.
+
+## Control Flow
+
+Follow the same branch structure as `DeepRefine.refine()`.
+
+```text
+target_queries = pending_history_queries()
+run "deeprefine history sync-memory" before loading pending history
+if target_queries is empty:
+    target_queries = [current session question]
+
+for question in target_queries:
+    interaction_history = []
+    for step in 1..MAX_HOPS:
+        print "[Step: {step}]"
+
+        if step == 1:
+            run: graphify query "<question>"
+            triples = parse NODE/EDGE rows into subject/relation/object triples
+            cap = MAX_TRIPLE_NUM_BY_STEP[0]
+            record retrieval.method = "graphify_query"
+        else:
+            entities = unique subjects/objects from previous triples
+            expand 1-hop neighbors from graphify-out/graph.json
+            cap = MAX_TRIPLE_NUM_BY_STEP[step - 1]
+            record retrieval.method = "k_hop_expansion" or "graphify_query+k_hop_expansion"
+
+        triples = dedupe; len(triples) <= cap
+        answerable, judgement_raw = LLM_judge(question, triples)
+        judgement_raw must be exactly <judge>Yes</judge> or <judge>No</judge>
+
+        append interaction_history with:
+          step, query, num_hops=(step - 1) * INCREMENT_HOP, base_top_k=10,
+          retrieved_subgraph, answerable, judgement_raw,
+          retrieval: {method, evidence: "<command output excerpt>"}
+
+        if answerable:
+            break
+
+    if len(interaction_history) <= 1:
+        set trace.early_exit = true
+        deeprefine loop finish --trace-file ...
+        continue
+
+    error_abduction = LLM_abduction(interaction_history[-HISTORY_HORIZON:])
+    error_abduction must be wrapped in <abduction>...</abduction>
+
+    actions = LLM_kg_refinement(last_hop.retrieved_subgraph, error_abduction, question)
+    actions must be wrapped in <refinement>...</refinement>
+
+    save actions to graphify-out/.deeprefine/refinement_actions_<id>.txt
+    deeprefine loop validate --trace-file ... --refinement-file ...
+    deeprefine review --trace-file ... --refinement-file ...
+    show review labels, evidence, warnings, and suggested replacements
+    hard stop; do not modify graph.json in this turn
+```
+
+Critical rule: refinement runs when `len(interaction_history) > 1`, not only
+when all judgements are `No`.
+
+## Evidence-Aware Review
+
+Before any graph write, run:
+
+```bash
+deeprefine review --trace-file graphify-out/.deeprefine/loop_trace_<id>.json --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+```
+
+The review labels every action:
+
+- `HIGH`: direct graph or code evidence exists.
+- `MEDIUM`: k-hop context supports the action, but direct code or exact-edge
+  evidence is missing.
+- `LOW`: endpoint nodes are ambiguous, too broad, cross-community, or cannot be
+  grounded in `graph.json`.
+
+Bare names such as `main()`, `run()`, `train()`, `test()`, and `setup()` are
+ambiguous even if they match only one node. Prefer file-qualified labels such
+as `trainer_Brain_CLS.py::train_epoch()`.
+
+`deeprefine apply` refuses LOW-confidence actions by default. Use
+`--allow-low-confidence` only when the user explicitly approves the risk.

--- a/deeprefine_skill/dsh_skill/references/deeprefine-workflow.md
+++ b/deeprefine_skill/dsh_skill/references/deeprefine-workflow.md
@@ -155,5 +155,6 @@ Bare names such as `main()`, `run()`, `train()`, `test()`, and `setup()` are
 ambiguous even if they match only one node. Prefer file-qualified labels such
 as `trainer_Brain_CLS.py::train_epoch()`.
 
-`deeprefine apply` refuses LOW-confidence actions by default. Use
+`deeprefine apply` aborts and writes nothing when any LOW-confidence action is
+present — it does NOT apply HIGH/MEDIUM actions while skipping LOW ones. Use
 `--allow-low-confidence` only when the user explicitly approves the risk.

--- a/deeprefine_skill/dsh_skill/references/llm-prompts.md
+++ b/deeprefine_skill/dsh_skill/references/llm-prompts.md
@@ -1,0 +1,96 @@
+# DeepRefine LLM Prompts
+
+Use these prompts when running the DeepRefine agent-native workflow. Do not
+paraphrase their required output tags.
+
+## Judgement
+
+Use for every hop.
+
+System:
+
+```text
+As an advanced judgement assistant, your task is to judge whether the given question is answerable based on the provided KG context.
+
+Evaluate whether the given question is answerable based on the provided KG context. Output your judgment in the following format:
+<judge>Yes</judge> or <judge>No</judge>
+
+**Important:** You must think carefully about the question and the KG context before making your judgment. And output your judgment result directly in the specified format.
+```
+
+User:
+
+```text
+Question: {question}
+Knowledge Graph (KG) context: {triples_string}
+```
+
+`{triples_string}` is one triple per line:
+
+```text
+subject | relation | object
+```
+
+## Error Abduction
+
+Use only when `len(interaction_history) > 1`.
+
+System:
+
+```text
+As an advanced error abduction assistant, your task is to analyze the error reasons based on the given interaction history.
+
+Analyze the reasons of the unanswerable questions based on the given interaction history from the incompleteness, incorrectness, and redundancy perspectives. Output your analysis in the following format:
+<abduction>...</abduction>
+
+**Important:** You must think carefully about the interaction history before making your analysis. And output your analysis result directly in the specified format.
+```
+
+User:
+
+```text
+Interaction history: {interaction_history}
+```
+
+Format `interaction_history` like DeepRefine:
+
+```text
+Step1:
+['Query': ..., 'Subgraph_hop': ..., 'Subgraph_content': ..., 'Answerable': ...]
+
+Step2:
+...
+```
+
+## KG Refinement Actions
+
+Use only when `len(interaction_history) > 1`.
+
+System:
+
+```text
+As an advanced knowledge graph refinement assistant, your task is to generate a series of actions (**within 10 actions**) to refine the given KG to make it more suitable for answering the given question.
+
+Based on the given KG and the analysed error reasons, refine the given KG to make it more easily for retrieval and answering the given question. You have the following three types of actions to conduct:
+
+- insert_edge(subject, relation, object): Insert a new edge into the KG to complete the missing information.
+- delete_edge(subject, relation, object): Delete an edge from the KG to remove the redundant information or conflicting information.
+- replace_node(old_entity, new_entity): Replace an entity in the KG to correct the errors or deal with disambiguation.
+
+Output a series of actions (**within 10 actions**) in the following format:
+<refinement>insert_edge("...", "...", "...")|delete_edge("...", "...", "...")|replace_node("...", "...")|...</refinement>
+
+**Important:** You must think carefully about the given KG and the analysed error reasons before making your refinement. DO NOT DELETE ANY IRRELEVANT TRIPLES FROM THE ORIGINAL KG. TRY TO KEEP THE ORIGINAL KG AS MUCH AS POSSIBLE. DO NOT GENERATE TOO MANY ACTIONS. And output your refinement result directly in the specified format.
+```
+
+User:
+
+```text
+Original Text: {original_text}
+KG: {triples_string}
+Question: {question}
+Error reasons: {error_reasons}
+```
+
+Use the last hop's `retrieved_subgraph` as `{triples_string}`. JSON list form is
+acceptable in the trace; use the string form for the prompt.

--- a/deeprefine_skill/dsh_skill/references/trace-and-commands.md
+++ b/deeprefine_skill/dsh_skill/references/trace-and-commands.md
@@ -1,0 +1,125 @@
+# DeepRefine Trace And Commands
+
+Use this reference when writing or validating loop traces and when executing the
+CLI command sequence.
+
+## Per-Query Checklist
+
+Report these items in chat for each query:
+
+```text
+[ ] Backup: graphify-out/.deeprefine/graph.json.bak
+[ ] loop_trace_<id>.json created
+[ ] Step 1: graphify query executed (evidence in trace)
+[ ] Each step: <judge>Yes|No</judge> shown in chat
+[ ] Hops stopped on Yes OR reached MAX_HOPS
+[ ] early_exit OR (abduction + refinement) per DeepRefine branch
+[ ] deeprefine loop validate passed
+[ ] deeprefine review generated with HIGH/MEDIUM/LOW labels
+[ ] graph.json intentionally left unchanged pending next-message approval OR user approved in a follow-up message
+[ ] deeprefine apply skipped in normal /deeprefine turn; only run after next-message approval
+[ ] deeprefine loop finish
+```
+
+## Commands In Order
+
+```bash
+# 0. KB project root; graphify-out/graph.json exists
+mkdir -p graphify-out/.deeprefine
+cp graphify-out/graph.json graphify-out/.deeprefine/graph.json.bak
+
+# 1. Sync graphify query memory to deeprefine history first.
+deeprefine history sync-memory
+
+# 2. Build target query list:
+#    - preferred: all pending from history.jsonl (refined != true)
+#    - fallback: current session question (single query)
+deeprefine history list --pending
+
+# 3. For each query in target list:
+deeprefine loop init --query "<question>"
+
+# 4-7. For each hop: graphify/graph read -> judge -> append to loop_trace_*.json
+
+# 8a. Early exit (len(history)==1 and answerable)
+deeprefine loop validate --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
+deeprefine loop finish --trace-file graphify-out/.deeprefine/loop_trace_<id>.json
+
+# 8b. Refinement path (len(history)>1): dry-run review first
+deeprefine loop validate --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+deeprefine review --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+
+# Hard stop.
+# A normal /deeprefine run must end here.
+# Report the review to the user and ask for explicit approval.
+# Do not run deeprefine apply in the same /deeprefine turn.
+
+# Approval-only follow-up commands, only after explicit approve/apply:
+deeprefine apply --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+# Optional explicit risk override:
+# deeprefine apply --allow-low-confidence --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+deeprefine loop finish --trace-file ... --refinement-file graphify-out/.deeprefine/refinement_actions_<id>.txt
+
+# 9. Repeat until all pending queries are reviewed/finished.
+```
+
+## `loop_trace_*.json` Schema
+
+```json
+{
+  "schema_version": 1,
+  "mode": "agent-loop",
+  "query": "what is dulce?",
+  "query_id": "5cdc0798eb59b486",
+  "constants": {
+    "max_hops": 4,
+    "increment_hop": 1,
+    "base_top_k": 10,
+    "max_triple_num_by_step": [5, 10, 15, 20],
+    "history_horizon_size": 4
+  },
+  "interaction_history": [
+    {
+      "step": 1,
+      "num_hops": 0,
+      "base_top_k": 10,
+      "query": "what is dulce?",
+      "retrieval": {
+        "method": "graphify_query",
+        "evidence": "graphify query \"what is dulce?\" -> ..."
+      },
+      "retrieved_subgraph": [
+        {"subject": "A", "relation": "r", "object": "B"}
+      ],
+      "answerable": false,
+      "judgement_raw": "<judge>No</judge>"
+    }
+  ],
+  "error_abduction_reason": "...",
+  "error_abduction_raw": "<abduction>...</abduction>",
+  "refinement_action_file": "graphify-out/.deeprefine/refinement_actions_<id>.txt",
+  "early_exit": false
+}
+```
+
+## Optional CLI Mode
+
+Only use this when the user explicitly requests `deeprefine refine` / full
+runtime mode.
+
+```bash
+conda activate atlastune
+export DEEPREFINE_EMBED_URL=... DEEPREFINE_LLM_URL=...
+deeprefine refine --query "..."       # dry-run proposal only
+# deeprefine refine --query "..." --apply   # only when explicitly requested
+```
+
+## Paths
+
+- `graphify-out/graph.json`
+- `graphify-out/.deeprefine/loop_trace_*.json`
+- `graphify-out/.deeprefine/refinement_actions_*.txt`
+- `graphify-out/.deeprefine/refinement_results_*.jsonl`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.md`
+- `graphify-out/.deeprefine/proposed_refinement_review_*.json`
+- `graphify-out/.deeprefine/graph.json.bak`

--- a/deeprefine_skill/installers.py
+++ b/deeprefine_skill/installers.py
@@ -1,10 +1,12 @@
-"""Installers for agent-platform skill files (Cursor, Copilot CLI, Gemini CLI, OpenCode).
+"""Installers for agent-platform skill files (Cursor, Copilot CLI, Gemini CLI,
+OpenCode, DeepSeek Harness).
 
 Each platform has a source SKILL.md variant (SKILL.md for Cursor,
 SKILL_COPILOT.md for Copilot CLI, gemini_extension/ for Gemini CLI,
-SKILL_OPENCODE.md for OpenCode) bundled in the wheel or found at the
-repo root during editable installs. The install/remove functions copy
-the appropriate variant into the platform-specific directory.
+SKILL_OPENCODE.md for OpenCode, dsh_skill/ for DeepSeek Harness) bundled in
+the wheel or found at the repo root during editable installs. The
+install/remove functions copy the appropriate variant into the
+platform-specific directory.
 """
 
 from __future__ import annotations
@@ -18,9 +20,11 @@ _SKILL_COPILOT_MD_NAME = "SKILL_COPILOT.md"
 _SKILL_OPENCODE_MD_NAME = "SKILL_OPENCODE.md"
 _CODEX_SKILL_DIR = "codex_skill"
 _CLAUDE_SKILL_DIR = "claude_skill"
+_DSH_SKILL_DIR = "dsh_skill"
 _CODEX_AGENTS_DIR = "agents"
 _CODEX_REFERENCES_DIR = "references"
 _CLAUDE_REFERENCES_DIR = "references"
+_DSH_REFERENCES_DIR = "references"
 _LEGACY_CODEX_AGENT_LOOP_REF_NAME = "deeprefine-agent-loop.md"
 _OPENAI_YAML_NAME = "openai.yaml"
 _GEMINI_EXTENSION_NAME = "deeprefine-skill"
@@ -383,6 +387,97 @@ def uninstall_claude_skill(*, project: bool) -> bool:
             removed = True
 
     for parent in [dest_dir / _CLAUDE_REFERENCES_DIR, dest_dir, dest_dir.parent]:
+        try:
+            parent.rmdir()
+        except OSError:
+            pass
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek Harness (dsh)
+# ---------------------------------------------------------------------------
+
+
+def dsh_skill_template_path() -> Path:
+    """Return the dsh skill template directory."""
+    bundled = Path(__file__).resolve().parent / _DSH_SKILL_DIR
+    if (bundled / _SKILL_MD_NAME).is_file():
+        return bundled
+    repo_root = Path(__file__).resolve().parents[1]
+    fallback = repo_root / "deeprefine_skill" / _DSH_SKILL_DIR
+    if (fallback / _SKILL_MD_NAME).is_file():
+        return fallback
+    raise FileNotFoundError(
+        "Missing dsh skill template (expected under "
+        "deeprefine_skill/dsh_skill/)."
+    )
+
+
+def skill_md_path_dsh() -> Path:
+    """Return the path to the dsh SKILL.md source."""
+    return dsh_skill_template_path() / _SKILL_MD_NAME
+
+
+def dsh_references_path() -> Path:
+    """Return the dsh references template directory."""
+    refs = dsh_skill_template_path() / _DSH_REFERENCES_DIR
+    if refs.is_dir():
+        return refs
+    raise FileNotFoundError(
+        "Missing dsh references template (expected under "
+        "deeprefine_skill/dsh_skill/references/)."
+    )
+
+
+def install_dsh_skill(*, project: bool) -> Path:
+    """Install the dsh skill into ``.dsh/skills/deeprefine/``.
+
+    Parameters
+    ----------
+    project : bool
+        If *True*, install under the current working directory
+        (``.dsh/skills/deeprefine/``).  If *False*, install under
+        ``~/.dsh/skills/deeprefine/`` (user-wide).
+
+    Returns
+    -------
+    Path
+        Destination path of the installed ``SKILL.md``.
+    """
+    src_skill = skill_md_path_dsh()
+    src_references = dsh_references_path()
+    if project:
+        dest_dir = Path.cwd() / ".dsh" / "skills" / "deeprefine"
+    else:
+        dest_dir = Path.home() / ".dsh" / "skills" / "deeprefine"
+    references_dir = dest_dir / _DSH_REFERENCES_DIR
+    references_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src_skill, dest_dir / _SKILL_MD_NAME)
+    for ref in src_references.glob("*.md"):
+        shutil.copy2(ref, references_dir / ref.name)
+    return dest_dir / _SKILL_MD_NAME
+
+
+def uninstall_dsh_skill(*, project: bool) -> bool:
+    """Remove a previously installed dsh skill."""
+    if project:
+        dest_dir = Path.cwd() / ".dsh" / "skills" / "deeprefine"
+    else:
+        dest_dir = Path.home() / ".dsh" / "skills" / "deeprefine"
+
+    removed = False
+    for dest in [
+        dest_dir / _SKILL_MD_NAME,
+        dest_dir / _DSH_REFERENCES_DIR / "deeprefine-workflow.md",
+        dest_dir / _DSH_REFERENCES_DIR / "llm-prompts.md",
+        dest_dir / _DSH_REFERENCES_DIR / "trace-and-commands.md",
+    ]:
+        if dest.is_file():
+            dest.unlink()
+            removed = True
+
+    for parent in [dest_dir / _DSH_REFERENCES_DIR, dest_dir, dest_dir.parent]:
         try:
             parent.rmdir()
         except OSError:

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -1,0 +1,65 @@
+# DeepRefine Skill for DeepSeek Harness (dsh)
+
+DeepRefine-Skill can be installed as a DeepSeek Harness (dsh) skill. This adds
+the `/deeprefine` agent-native refinement workflow to dsh while keeping the
+existing platform adapters (Cursor, Copilot CLI, Gemini CLI, Codex, Claude
+Code, OpenCode) unchanged.
+
+## Prerequisites
+
+```bash
+pip install -e /path/to/DeepRefine-Skill   # or: pip install deeprefine-cli
+```
+
+The skill is a plain Markdown bundle and does not require any dsh plugin or
+Node.js code.
+
+## Setup
+
+Install into the current project:
+
+```bash
+deeprefine dsh install
+# → .dsh/skills/deeprefine/SKILL.md + references/
+```
+
+Install for all projects:
+
+```bash
+deeprefine dsh install --user
+# → ~/.dsh/skills/deeprefine/
+```
+
+Remove with:
+
+```bash
+deeprefine dsh uninstall
+```
+
+dsh discovers skills under `<projectRoot>/.dsh/skills` (project) and
+`~/.dsh/skills` (user). The skill is picked up automatically; a running session
+hot-refreshes its catalog after install, so no restart is required.
+
+## Usage
+
+From a knowledge-base project root where `graphify-out/graph.json` exists:
+
+```text
+/deeprefine
+```
+
+The model loads the skill and runs the canonical DeepRefine loop: sync memory
+→ select pending queries → retrieve → `<judge>` → (multi-hop) error abduction →
+`<refinement>` → `loop validate` → `review`. A normal `/deeprefine` turn is
+dry-run only and stops at the HIGH/MEDIUM/LOW report for explicit approval; it
+never calls `deeprefine apply` on its own.
+
+## Notes
+
+- `/deeprefine` expects a project with `graphify-out/graph.json`; without one it
+  reports that Graphify outputs are missing.
+- `deeprefine apply` aborts and writes nothing if any LOW-confidence action is
+  present. Use `--allow-low-confidence` only with explicit user approval.
+- The dsh skill is a platform adapter for the same DeepRefine control flow; see
+  `deeprefine_skill/dsh_skill/references/` for the workflow, prompts, and trace
+  schema it loads on demand.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ deeprefine_skill = [
     "codex_skill/references/*.md",
     "claude_skill/SKILL.md",
     "claude_skill/references/*.md",
+    "dsh_skill/SKILL.md",
+    "dsh_skill/references/*.md",
     "commands/opencode/*.md",
     "gemini_extension/gemini-extension.json",
     "gemini_extension/GEMINI.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 authors = [
     {name = "HKUST-KnowComp"},
 ]
-keywords = ["deeprefine", "graphify", "knowledge-graph", "rag", "cursor", "copilot", "copilot-cli", "gemini-cli", "gemini", "codex", "opencode", "claude-code", "claude", "agent-skill"]
+keywords = ["deeprefine", "graphify", "knowledge-graph", "rag", "cursor", "copilot", "copilot-cli", "gemini-cli", "gemini", "codex", "opencode", "claude-code", "claude", "dsh", "deepseek-harness", "agent-skill"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",

--- a/tests/test_dsh_integration.py
+++ b/tests/test_dsh_integration.py
@@ -1,0 +1,217 @@
+"""Integration tests for DeepSeek Harness (dsh) skill — CLI layer + frontmatter.
+
+dsh discovers skills under ``.dsh/skills/<name>/SKILL.md`` (project) or
+``~/.dsh/skills/<name>/SKILL.md`` (user) and follows the same Agent Skills
+contract as Claude Code: YAML frontmatter with a kebab-case ``name`` and a
+``description`` the model uses to decide when to invoke the skill.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_DSH = REPO_ROOT / "deeprefine_skill" / "dsh_skill" / "SKILL.md"
+REFERENCES_DIR = REPO_ROOT / "deeprefine_skill" / "dsh_skill" / "references"
+EXPECTED_REFERENCES: tuple[str, ...] = (
+    "deeprefine-workflow.md",
+    "llm-prompts.md",
+    "trace-and-commands.md",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(text: str) -> dict[str, Any]:
+    """Parse YAML frontmatter from a markdown file (between ``---`` fences)."""
+    parts = text.split("---")
+    if len(parts) < 3:
+        return {}
+    return yaml.safe_load(parts[1]) or {}
+
+
+def _run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run ``python -m deeprefine_skill.cli`` with given args."""
+    cmd = [sys.executable, "-m", "deeprefine_skill.cli", *args]
+    return subprocess.run(
+        cmd,
+        text=True,
+        cwd=str(cwd or REPO_ROOT),
+        capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter tests (no filesystem side-effects)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillFrontmatter:
+    """Verify dsh SKILL.md frontmatter satisfies the dsh skill contract."""
+
+    def test_name_field_kebab_case(self) -> None:
+        """Required field: ``name`` must be kebab-case (lowercase + hyphens)."""
+        text = SKILL_DSH.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert "name" in fm, "missing required 'name' field"
+        name: str = fm["name"]
+        assert name == "deeprefine"
+        assert all(c.islower() or c.isdigit() or c == "-" for c in name), (
+            f"name {name!r} is not kebab-case (dsh ignores non-kebab names)"
+        )
+
+    def test_description_field_present(self) -> None:
+        """Required field: ``description`` (1-1024 chars)."""
+        text = SKILL_DSH.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert "description" in fm, "missing required 'description' field"
+        desc = fm["description"]
+        if isinstance(desc, str):
+            assert 1 <= len(desc) <= 1024, f"description length {len(desc)} out of range [1,1024]"
+
+    def test_no_allowed_tools_leak(self) -> None:
+        """Claude Code-specific field must NOT leak into the dsh skill."""
+        text = SKILL_DSH.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert "allowed-tools" not in fm, (
+            "allowed-tools is Claude Code-only and must not appear in dsh SKILL.md"
+        )
+
+    def test_model_invocation_enabled(self) -> None:
+        """The model must be able to auto-invoke the skill in dsh."""
+        text = SKILL_DSH.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert fm.get("disable-model-invocation") is False, (
+            "disable-model-invocation must be false for auto-invocation in dsh"
+        )
+
+    @pytest.mark.parametrize("ref_name", EXPECTED_REFERENCES)
+    def test_reference_files_exist(self, ref_name: str) -> None:
+        """Every reference linked from SKILL.md must be bundled."""
+        ref_path = REFERENCES_DIR / ref_name
+        assert ref_path.is_file(), f"reference file missing: {ref_path}"
+        assert ref_path.read_text(encoding="utf-8").strip(), (
+            f"reference file empty: {ref_path}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Installer tests (temporary directories, no side-effects)
+# ---------------------------------------------------------------------------
+
+
+class TestDshInstall:
+    """End-to-end install/uninstall in isolated temp dirs."""
+
+    def _run_install(self, cwd: Path, *, project: bool = True) -> subprocess.CompletedProcess[str]:
+        args = ["dsh", "install"]
+        if project:
+            args.append("--project")
+        return _run_cli(*args, cwd=cwd)
+
+    def _run_uninstall(self, cwd: Path, *, project: bool = True) -> subprocess.CompletedProcess[str]:
+        args = ["dsh", "uninstall"]
+        if project:
+            args.append("--project")
+        return _run_cli(*args, cwd=cwd)
+
+    def test_install_creates_skill_file(self, tmp_path: Path) -> None:
+        """Install creates .dsh/skills/deeprefine/SKILL.md."""
+        skill_dest = tmp_path / ".dsh" / "skills" / "deeprefine" / "SKILL.md"
+        result = self._run_install(cwd=tmp_path)
+        assert result.returncode == 0, f"install failed: {result.stderr}"
+        assert skill_dest.is_file(), f"SKILL.md not created at {skill_dest}"
+
+    def test_install_creates_references(self, tmp_path: Path) -> None:
+        """Install creates all reference files under references/."""
+        result = self._run_install(cwd=tmp_path)
+        assert result.returncode == 0, f"install failed: {result.stderr}"
+        for ref_name in EXPECTED_REFERENCES:
+            ref_path = tmp_path / ".dsh" / "skills" / "deeprefine" / "references" / ref_name
+            assert ref_path.is_file(), f"reference {ref_name} not created at {ref_path}"
+
+    def test_uninstall_removes_skill_file(self, tmp_path: Path) -> None:
+        """Uninstall removes .dsh/skills/deeprefine/SKILL.md."""
+        self._run_install(cwd=tmp_path)
+        skill_dest = tmp_path / ".dsh" / "skills" / "deeprefine" / "SKILL.md"
+        assert skill_dest.is_file(), "precondition: install must succeed"
+
+        result = self._run_uninstall(cwd=tmp_path)
+        assert result.returncode == 0, f"uninstall failed: {result.stderr}"
+        assert not skill_dest.exists(), f"SKILL.md not removed: {skill_dest}"
+
+    def test_uninstall_removes_references(self, tmp_path: Path) -> None:
+        """Uninstall removes all reference files."""
+        self._run_install(cwd=tmp_path)
+        for ref_name in EXPECTED_REFERENCES:
+            ref_path = tmp_path / ".dsh" / "skills" / "deeprefine" / "references" / ref_name
+            assert ref_path.is_file(), f"precondition: {ref_name} must exist"
+
+        result = self._run_uninstall(cwd=tmp_path)
+        assert result.returncode == 0
+        for ref_name in EXPECTED_REFERENCES:
+            ref_path = tmp_path / ".dsh" / "skills" / "deeprefine" / "references" / ref_name
+            assert not ref_path.exists(), f"reference {ref_name} not removed"
+
+    def test_uninstall_clean_dirs(self, tmp_path: Path) -> None:
+        """Uninstall cleans up empty parent directories."""
+        self._run_install(cwd=tmp_path)
+        self._run_uninstall(cwd=tmp_path)
+
+        skill_deep_dir = tmp_path / ".dsh" / "skills" / "deeprefine"
+        assert not skill_deep_dir.exists(), f"skill dir not cleaned: {skill_deep_dir}"
+
+    def test_install_idempotent(self, tmp_path: Path) -> None:
+        """Install twice should succeed (overwrite)."""
+        r1 = self._run_install(cwd=tmp_path)
+        r2 = self._run_install(cwd=tmp_path)
+        assert r1.returncode == 0
+        assert r2.returncode == 0, f"second install failed: {r2.stderr}"
+        skill_dest = tmp_path / ".dsh" / "skills" / "deeprefine" / "SKILL.md"
+        assert skill_dest.is_file()
+
+
+# ---------------------------------------------------------------------------
+# CLI help tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliHelp:
+    """Verify CLI --help output for dsh subcommands."""
+
+    def test_dsh_help_shows_subcommands(self) -> None:
+        """``deeprefine dsh --help`` shows install and uninstall."""
+        result = _run_cli("dsh", "--help")
+        assert result.returncode == 0
+        out = result.stdout
+        assert "install" in out
+        assert "uninstall" in out
+
+    def test_install_help_shows_flags(self) -> None:
+        """``deeprefine dsh install --help`` shows --project and --user."""
+        result = _run_cli("dsh", "install", "--help")
+        assert result.returncode == 0
+        out = result.stdout
+        assert "--project" in out, f"missing --project flag in help: {out}"
+        assert "--user" in out, f"missing --user flag in help: {out}"
+
+    def test_uninstall_help_shows_flags(self) -> None:
+        """``deeprefine dsh uninstall --help`` shows --project and --user."""
+        result = _run_cli("dsh", "uninstall", "--help")
+        assert result.returncode == 0
+        out = result.stdout
+        assert "--project" in out
+        assert "--user" in out


### PR DESCRIPTION
Add a dsh skill template (deeprefine_skill/dsh_skill/) that follows the same Agent Skills contract as the Claude Code adapter, and wire it into the installer and CLI:

- deeprefine dsh install [--project|--user] / deeprefine dsh uninstall
- installs SKILL.md + canonical references into .dsh/skills/deeprefine/ (project) or ~/.dsh/skills/deeprefine/ (user)
- bundle dsh_skill/** in the wheel package-data
- tests/test_dsh_integration.py: frontmatter contract, install/uninstall, CLI help